### PR TITLE
Add custom node for cross referencing API functions, fix deploy

### DIFF
--- a/app/components/CrossRef.tsx
+++ b/app/components/CrossRef.tsx
@@ -8,7 +8,7 @@ interface CrossRefProps {
 
 export function CrossRef({href, children}: CrossRefProps) {
     return (
-        <Link href={href.includes("https://") || href.includes("http://") ? href : `reference/${href}`}>
+        <Link href={href.includes("https://") || href.includes("http://") ? href : `/reference/${href}`}>
           {children}
         </Link>
       );

--- a/app/components/CrossRef.tsx
+++ b/app/components/CrossRef.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+interface CrossRefProps {
+  href: string;
+  children: ReactNode;
+}
+
+export function CrossRef({href, children}: CrossRefProps) {
+    return (
+        <Link href={href.includes("https://") || href.includes("http://") ? href : `reference/${href}`}>
+          {children ? children : href}
+        </Link>
+      );
+}
+
+export default CrossRef;

--- a/app/components/CrossRef.tsx
+++ b/app/components/CrossRef.tsx
@@ -9,7 +9,7 @@ interface CrossRefProps {
 export function CrossRef({href, children}: CrossRefProps) {
     return (
         <Link href={href.includes("https://") || href.includes("http://") ? href : `reference/${href}`}>
-          {children ? children : href}
+          {children}
         </Link>
       );
 }

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useRouter } from 'next/router';
 import Link from 'next/link';
 
 interface Page {
@@ -24,8 +23,6 @@ interface SideNavProps {
 
 
 export function SideNav({ items }: SideNavProps) {
-  const router = useRouter();
-
   return (
     <nav className="sidenav">
       {items.map((item, itemIndex) => {

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useRouter } from 'next/router';
 import Link from 'next/link';
 
 interface Page {
@@ -23,6 +24,8 @@ interface SideNavProps {
 
 
 export function SideNav({ items }: SideNavProps) {
+  const router = useRouter();
+
   return (
     <nav className="sidenav">
       {items.map((item, itemIndex) => {

--- a/app/components/index.js
+++ b/app/components/index.js
@@ -1,5 +1,6 @@
 export * from './Callout';
 export * from './CodeBlock';
+export * from './CrossRef';
 export * from './FuncReference';
 export * from './Heading';
 export * from './SideNav';

--- a/app/markdoc/nodes/index.ts
+++ b/app/markdoc/nodes/index.ts
@@ -1,3 +1,5 @@
+// markdoc/nodes/index.ts
 /* Use this file to export your markdoc nodes */
 export * from './fence.markdoc';
 export * from './heading.markdoc';
+export * from './link.markdoc';

--- a/app/markdoc/nodes/link.markdoc.ts
+++ b/app/markdoc/nodes/link.markdoc.ts
@@ -1,0 +1,10 @@
+import { CrossRef } from '../../components';
+
+export const link = {
+  render: CrossRef,
+  attributes: {
+    href: {
+      type: String
+    }
+  }
+};

--- a/app/next-env.d.ts
+++ b/app/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Link from 'next/link';
 
 import { SideNav, TableOfContents } from '../components';
 import { NavigationItem } from '../components/SideNav';

--- a/app/pages/getting-started.md
+++ b/app/pages/getting-started.md
@@ -3,3 +3,9 @@ title: Getting started
 ---
 
 Hello world
+
+[](luma.examples.fib)
+
+[The example fibonacci method](luma.examples.fib)
+
+[You'll get no sympathy from me](https://github.com/luma-docs/luma)

--- a/app/pages/getting-started.md
+++ b/app/pages/getting-started.md
@@ -4,8 +4,6 @@ title: Getting started
 
 Hello world
 
-[](luma.examples.fib)
-
 [The example fibonacci method](luma.examples.fib)
 
 [You'll get no sympathy from me](https://github.com/luma-docs/luma)

--- a/app/public/luma.yaml
+++ b/app/public/luma.yaml
@@ -1,4 +1,4 @@
-name: math
+name: ike
 navigation:
 - path: getting-started.md
   title: Getting Started

--- a/src/luma/deploy.py
+++ b/src/luma/deploy.py
@@ -78,7 +78,7 @@ def deploy_project(build_path: str, package_name: str) -> str:
         body = response.json()
         return body["deploymentId"]
     else:
-        logger.info(f"Deployment failed: {response.status_code} {response.text}")
+        logger.error(f"Deployment failed: {response.status_code} {response.text}")
         raise typer.Exit(1)
 
 
@@ -99,10 +99,10 @@ def monitor_deployment(deployment_id: str, package_name: str):
                 logger.info(f"Deployment successful! {body["deploymentUrl"]}")
                 return
             elif status == "ERROR":
-                logger.info(f"Deployment failed: {body["errorMessage"]}")
+                logger.error(f"Deployment failed: {body["errorMessage"]}")
                 return
             elif status == "CANCELED":
-                logger.info(f"Deployment canceled: {body["errorMessage"]}")
+                logger.warn(f"Deployment canceled: {body["errorMessage"]}")
                 return
 
             time.sleep(POLLING_INTERVAL_SECONDS)

--- a/src/luma/main.py
+++ b/src/luma/main.py
@@ -81,8 +81,8 @@ def deploy():
 
     try:
         build_path = build_project(node_root)
-        deployment_id = deploy_project(build_path, config.package_name)
-        monitor_deployment(deployment_id, config.package_name)
+        deployment_id = deploy_project(build_path, config.name)
+        monitor_deployment(deployment_id, config.name)
     finally:
         cleanup_build(build_path)
 

--- a/starter/getting-started.md
+++ b/starter/getting-started.md
@@ -3,3 +3,9 @@ title: Getting started
 ---
 
 Hello world
+
+[](luma.examples.fib)
+
+[The example fibonacci method](luma.examples.fib)
+
+[You'll get no sympathy from me](https://github.com/luma-docs/luma)

--- a/starter/luma.yaml
+++ b/starter/luma.yaml
@@ -1,4 +1,4 @@
-name: math
+name: ike
 navigation:
 - path: getting-started.md
   title: Getting Started


### PR DESCRIPTION
- Override the default link node to cross reference APIs. Check for `https://` or `http://` to create a normal link instead.
- Fix deploy errors