### PR TITLE
Add minimum width to SideNav

### DIFF
--- a/src/luma/app/components/SideNav.module.css
+++ b/src/luma/app/components/SideNav.module.css
@@ -8,6 +8,7 @@ nav.container {
   height: 100vh;
   padding: 1.5rem 1rem 1rem;
   border-right: 1px solid var(--border-color);
+  min-width: 15rem;
 }
 
 span.sectionTitle {


### PR DESCRIPTION
## Summary
- Adds a minimum width of 15rem (240px) to the SideNav component

## Rationale
This ensures the sidebar maintains an appropriate width and doesn't collapse too small, which improves aesthetics and usability of navigation items. The fixed minimum width provides a consistent user experience across different viewport sizes.

**Before**
<img width="1624" height="954" alt="image" src="https://github.com/user-attachments/assets/d0ee6a60-9ed7-4392-8670-e8b7e1d11a8e" />

**After**
<img width="1624" height="954" alt="image" src="https://github.com/user-attachments/assets/cf229b29-0ea4-4170-aad2-0bcfe54866a3" />
