### PR TITLE
Refactor CodeBlock to use CSS modules

### DIFF
--- a/src/luma/app/components/CodeBlock.module.css
+++ b/src/luma/app/components/CodeBlock.module.css
@@ -1,0 +1,12 @@
+.code {
+  position: relative;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+/* Override Prism styles */
+.code :global(pre[class*="language-"]) {
+  text-shadow: none;
+  border-radius: 4px;
+  margin: 0;
+}

--- a/src/luma/app/components/CodeBlock.module.css
+++ b/src/luma/app/components/CodeBlock.module.css
@@ -2,6 +2,7 @@
   position: relative;
   border: 1px solid var(--border-color);
   border-radius: 4px;
+  margin-bottom: 1rem;
 }
 
 /* Override Prism styles */

--- a/src/luma/app/components/CodeBlock.tsx
+++ b/src/luma/app/components/CodeBlock.tsx
@@ -1,10 +1,11 @@
 import Prism from "prismjs";
-
 import * as React from "react";
 
+import styles from "./CodeBlock.module.css";
+
 interface CodeBlockProps {
-  children: React.ReactNode; // Typing children as ReactNode allows any valid React child
-  "data-language": string; // Assuming language is a string
+  children: React.ReactNode;
+  "data-language": string;
 }
 
 export function CodeBlock({
@@ -18,26 +19,10 @@ export function CodeBlock({
   }, [children]);
 
   return (
-    <div className="code" aria-live="polite">
+    <div className={styles.code} aria-live="polite">
       <pre ref={ref} className={`language-${language}`}>
         {children}
       </pre>
-      <style jsx>
-        {`
-          .code {
-            position: relative;
-            border: 1px solid var(--border-color);
-            border-radius: 4px;
-          }
-
-          /* Override Prism styles */
-          .code :global(pre[class*="language-"]) {
-            text-shadow: none;
-            border-radius: 4px;
-            margin: 0;
-          }
-        `}
-      </style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract inline styles from CodeBlock component into a separate CSS module file
- Remove `<style jsx>` block in favor of imported CSS module
- Follow Next.js best practices for component styling with CSS Modules

## Benefits
- Better separation of concerns (logic vs. presentation)
- Automatic CSS scoping through CSS Modules
- Improved build-time optimization
- Easier to maintain and test styles independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)