### PR TITLE
Add footer component with 'Made with Luma' branding

### DIFF
--- a/src/luma/app/components/Footer.module.css
+++ b/src/luma/app/components/Footer.module.css
@@ -1,0 +1,21 @@
+.footer {
+  margin-top: auto;
+  padding-top: 2rem;
+  padding-bottom: 4rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.link {
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 400;
+  transition: color 0.2s;
+}
+
+.link:hover {
+  color: var(--color-text-primary);
+}

--- a/src/luma/app/components/Footer.tsx
+++ b/src/luma/app/components/Footer.tsx
@@ -1,0 +1,16 @@
+import styles from "./Footer.module.css";
+
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <a
+        href="https://luma-docs.org"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.link}
+      >
+        Made with Luma
+      </a>
+    </footer>
+  );
+}

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 
 import { SideNav, TableOfContents } from "../components";
+import { Footer } from "../components/Footer";
 import VersionSelector from "../components/VersionSelector";
 import "prismjs";
 // Import other Prism themes here
@@ -129,7 +130,10 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         <main className="main">
           <div className="container">
             <div className="content">
-              <Component {...pageProps} />
+              <div className="content-wrapper">
+                <Component {...pageProps} />
+              </div>
+              <Footer />
             </div>
             {validTocItems.length > 1 ? (
               <TableOfContents toc={validTocItems} />
@@ -163,13 +167,21 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
             padding-right: 4rem;
             display: flex;
             justify-content: center;
+            min-height: 100%;
           }
           .content {
             width: 640px;
-            margin: 0 auto 96px;
+            margin: 0 auto 1rem;
             padding-top: 48px;
+            display: flex;
+            flex-direction: column;
+            min-height: calc(100vh - 48px - 96px - 4rem);
           }
-          .content :global(*:first-child) {
+          .content-wrapper {
+            flex: 1 0 auto;
+            padding-bottom: 2rem;
+          }
+          .content-wrapper :global(*:first-child) {
             margin-top: 0;
           }
           .toc-placeholder {


### PR DESCRIPTION
## Summary
- Create new Footer component that displays "Made with Luma" linking to luma-docs.org
- Position footer at bottom right of each documentation page
- Refactor using CSS modules following Next.js best practices

## Features
- **New Footer component** (`Footer.tsx`) with dedicated CSS module
- **Smart positioning**: Uses flexbox to keep footer at viewport bottom for short content
- **Consistent styling**: Matches design system with `var(--border-color)` and text colors
- **Interactive**: Smooth hover effect on link
- **Accessible**: Proper `target="_blank"` with `rel="noopener noreferrer"`

## Layout Changes
- Added `content-wrapper` div to separate page content from footer
- Flexbox layout ensures footer stays at bottom on pages with minimal content
- Natural content flow maintained for longer pages
- Increased spacing between content and footer

## Test plan
- [x] Verify footer appears at bottom right of all pages
- [x] Check footer stays at viewport bottom on short pages
- [x] Confirm footer appears after content on long pages
- [x] Test link opens in new tab and navigates to https://luma-docs.org
- [x] Verify hover effect works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)