### PR TITLE
Add automated version bumping and tagging to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,15 +5,20 @@ on:
 
 jobs:
   pypi:
-    name: Build and Publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
 
       - name: Install Poetry
         run: |
@@ -23,8 +28,43 @@ jobs:
       - name: Configure Poetry
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
 
+      - name: Bump version
+        id: bump_version
+        run: |
+          # Read current version from pyproject.toml
+          CURRENT_VERSION=$(grep -oP '(?<=^version = ")[^"]+' pyproject.toml)
+          echo "Current version: $CURRENT_VERSION"
+
+          # Parse semantic version and bump minor version
+          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+          NEW_MINOR=$((minor + 1))
+          NEW_VERSION="${major}.${NEW_MINOR}.0"
+          echo "New version: $NEW_VERSION"
+
+          # Update pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
+
+          # Update package.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" src/luma/app/package.json
+
+          # Set output for later steps
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit version bump
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add pyproject.toml src/luma/app/package.json
+          git commit -m "Bump version to ${{ steps.bump_version.outputs.new_version }}"
+          git push
+
       - name: Build package
         run: poetry build
 
       - name: Publish package
         run: poetry publish
+
+      - name: Create Git tag
+        run: |
+          git tag "v${{ steps.bump_version.outputs.new_version }}"
+          git push origin "v${{ steps.bump_version.outputs.new_version }}"


### PR DESCRIPTION
## Summary

- Automates version bumping in the GitHub Actions release workflow
- Bumps minor version in both `pyproject.toml` and `src/luma/app/package.json` to maintain version consistency
- Commits version changes back to the repository during the release process
- Creates and pushes git tags for new releases

## Changes

The release workflow now:
1. Automatically increments the minor version (e.g., 0.1.0 → 0.2.0)
2. Updates both Python and Next.js package versions synchronously
3. Commits these changes with proper git attribution
4. Creates a corresponding git tag (e.g., `v0.2.0`) after successful publication

## Test plan

- [x] Review workflow syntax and logic
- [ ] Trigger workflow manually via workflow_dispatch to verify:
  - Version bumping works correctly
  - Both files are updated
  - Commit is created and pushed
  - Package builds and publishes successfully
  - Git tag is created and pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)