### PR TITLE
Bump version to 0.0.10 and standardize metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ include = [
     { path = "starter", format = "wheel" },
     { path = "app", format = "wheel" },
 ]
-version = "0.0.9"
+version = "0.0.10"
 description = ""
-authors = ["Balaji Veeramani <bveeramani@berkeley.edu>", "Nicholas Spevacek <nspevacek@wisc.edu>"]
+authors = ["The Luma Team <bveeramani@berkeley.edu>"]
 readme = "README.md"
 packages = [{ include = "luma", from = "src" }]
-license = "Apache 2.0"
+license = "Apache-2.0"
 
 [tool.poetry.scripts]
 luma = "luma.main:main"

--- a/src/luma/app/package.json
+++ b/src/luma/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump version from 0.0.9 to 0.0.10 in both `pyproject.toml` and `src/luma/app/package.json`
- Standardize authors field to "The Luma Team <bveeramani@berkeley.edu>"
- Fix license identifier to proper SPDX format: `Apache-2.0` (was `Apache 2.0`)

## Test plan
- [ ] Verify version numbers match in both files (0.0.10)
- [ ] Confirm package builds successfully with `poetry build`
- [ ] Verify SPDX license identifier is correct for PyPI/Poetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)