### PR TITLE
Add argument types to references

### DIFF
--- a/src/luma/models.py
+++ b/src/luma/models.py
@@ -51,7 +51,10 @@ class PyFunc(PyObj):
         if self.args:
             markdown += "\n**Arguments**\n\n"
             for arg in self.args:
-                markdown += f"- **{arg.name}**: {arg.desc}\n"
+                if arg.type:
+                    markdown += f"- **{arg.name}** ({arg.type}): {arg.desc}\n"
+                else:
+                    markdown += f"- **{arg.name}**: {arg.desc}\n"
 
         if self.returns:
             markdown += f"\n**Returns**\n\n{self.returns}\n"
@@ -83,7 +86,10 @@ class PyClass(PyObj):
         if self.args:
             markdown += "\n**Arguments**\n\n"
             for arg in self.args:
-                markdown += f"- **{arg.name}**: {arg.desc}\n"
+                if arg.type:
+                    markdown += f"- **{arg.name}** ({arg.type}): {arg.desc}\n"
+                else:
+                    markdown += f"- **{arg.name}**: {arg.desc}\n"
 
         if self.examples:
             markdown += "\n**Examples**\n"

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -117,7 +117,7 @@ def _parse_func(func: FunctionType, qualname: str) -> PyFunc:
     signature = _get_signature(func, qualname)
     parsed = parse(func.__doc__)
     summary, desc = _get_summary_and_desc(parsed)
-    param_types = _get_param_types(func, qualname)
+    param_types = _get_param_types(func)
 
     args = []
     for param in parsed.params:
@@ -199,11 +199,12 @@ def _get_signature(obj: Union[FunctionType, type], name: str) -> str:
     return f"{name}{parameters}"
 
 
-def _get_param_types(obj: Union[FunctionType, type], name: str) -> dict:
+def _get_param_types(obj: Union[FunctionType, type]) -> dict:
     assert isinstance(obj, (FunctionType, type)), obj
+    
+    init_or_func = obj.__init__ if isinstance(obj, type) else obj
     parameters = {}
 
-    init_or_func = obj.__init__ if isinstance(obj, type) else obj
     if init_or_func != object.__init__:
         signature = inspect.signature(init_or_func)
 

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -122,7 +122,9 @@ def _parse_func(func: FunctionType, qualname: str) -> PyFunc:
     args = []
     for param in parsed.params:
         args.append(
-            PyArg(name=param.arg_name, type=param_types.get(param.arg_name, None), desc=param.description)
+            PyArg(name=param.arg_name, 
+                  type=param_types.get(param.arg_name, param.type_name), 
+                  desc=param.description)
         )
 
     returns = parsed.returns.description if parsed.returns else None
@@ -202,11 +204,10 @@ def _get_signature(obj: Union[FunctionType, type], name: str) -> str:
 def _get_param_types(obj: Union[FunctionType, type]) -> dict:
     assert isinstance(obj, (FunctionType, type)), obj
     
-    init_or_func = obj.__init__ if isinstance(obj, type) else obj
     parameters = {}
 
-    if init_or_func != object.__init__:
-        signature = inspect.signature(init_or_func)
+    if not isinstance(obj, type):
+        signature = inspect.signature(obj)
 
         for param_name, param in signature.parameters.items():
             if param.annotation.__name__ != "_empty":

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -214,4 +214,3 @@ def _get_param_types(obj: Union[FunctionType, type]) -> dict:
                 parameters[param_name] = param.annotation.__name__
 
     return parameters
-

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from types import FunctionType
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from docstring_parser import Docstring, parse
 
@@ -201,7 +201,15 @@ def _get_signature(obj: Union[FunctionType, type], name: str) -> str:
     return f"{name}{parameters}"
 
 
-def _get_param_types(obj: Union[FunctionType, type]) -> dict:
+def _get_param_types(obj: Union[FunctionType, type]) -> Dict[str, Optional[str]]:
+    """Get parameter types from type hints specified in a function signature.
+
+    Args:
+        obj: The function to parse.
+
+    Returns:
+        A dictionary of parameter names mapped to signature type hints. 
+    """
     assert isinstance(obj, (FunctionType, type)), obj
     
     parameters = {}

--- a/tests/unit/parsing/test_cls.py
+++ b/tests/unit/parsing/test_cls.py
@@ -48,7 +48,7 @@ def test_comprehensive():
     assert class_definition.examples == [DocstringExample(desc=None, code=">>> A(0)")]
     assert class_definition.signature == "A(x: int)"
     assert class_definition.args == [
-        PyArg(name="x", type=None, desc="Constructor arg description.")
+        PyArg(name="x", type="int", desc="Constructor arg description.")
     ]
     assert len(class_definition.methods) == 1
 

--- a/tests/unit/parsing/test_func.py
+++ b/tests/unit/parsing/test_func.py
@@ -155,7 +155,7 @@ def test_args():
     definition = parse_obj(f, "f")
 
     # TODO: Infer parameter type from the signature.
-    assert definition.args == [PyArg(name="x", type=None, desc="A number.")]
+    assert definition.args == [PyArg(name="x", type="int", desc="A number.")]
 
 
 def test_returns():
@@ -204,7 +204,7 @@ def test_comprehensive():
     ]
     assert definition.signature == "f(x: int, y: int) -> int"
     assert definition.args == [
-        PyArg(name="x", type=None, desc="The first number."),
-        PyArg(name="y", type=None, desc="The second number."),
+        PyArg(name="x", type="int", desc="The first number."),
+        PyArg(name="y", type="int", desc="The second number."),
     ]
     assert definition.returns == "The sum of x and y."

--- a/tests/unit/test_to_markdown.py
+++ b/tests/unit/test_to_markdown.py
@@ -27,7 +27,7 @@ desc
 
 **Arguments**
 
-- **arg**: arg desc
+- **arg** (int): arg desc
 
 **Returns**
 
@@ -78,7 +78,7 @@ desc
 
 **Arguments**
 
-- **arg**: arg desc
+- **arg** (int): arg desc
 
 **Examples**
 


### PR DESCRIPTION
Parse arg types from signature and add to arg list in references (if type is specified). Example at https://arg-typing.luma-docs.org/latest/example-references