### PR TITLE
Fix text overflow for long inline code

### DIFF
--- a/src/luma/app/styles/globals.css
+++ b/src/luma/app/styles/globals.css
@@ -67,6 +67,11 @@ li.active {
   color: #282a30;
 }
 
+code {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
 hr {
   border: none;
   border-top: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- Add word-wrapping CSS rules to prevent long inline code snippets from extending beyond the content width
- Ensures proper text wrapping within the 640px content area

## Changes
- Added `overflow-wrap: break-word` and `word-wrap: break-word` to `code` elements in `globals.css`

**Before**

<img width="1624" height="954" alt="image" src="https://github.com/user-attachments/assets/b3702be6-90c1-4d44-bde7-e0ad0b187b82" />


**After**

<img width="1624" height="954" alt="image" src="https://github.com/user-attachments/assets/74bc0f82-cc9f-4937-9c03-c082353c3173" />

