### PR TITLE
Add tabs component for tabbed content

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -1,0 +1,89 @@
+# Tabs
+
+Tabs allow you to organize content into multiple panels, where only one panel is visible at a time.
+
+## Example
+
+{% tabs %}
+
+{% tab name="Parquet" %}
+
+This is an example of reading Parquet files.
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("data.parquet")
+```
+
+{% /tab %}
+
+{% tab name="JSON" %}
+
+This is an example of reading JSON files.
+
+```python
+import pandas as pd
+
+df = pd.read_json("data.json")
+```
+
+{% /tab %}
+
+{% tab name="CSV" %}
+
+This is an example of reading CSV files.
+
+```python
+import pandas as pd
+
+df = pd.read_csv("data.csv")
+```
+
+{% /tab %}
+
+{% /tabs %}
+
+---
+
+````markdown
+{% tabs %}
+
+{% tab name="Parquet" %}
+
+This is an example of reading Parquet files.
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("data.parquet")
+```
+
+{% /tab %}
+
+{% tab name="JSON" %}
+
+This is an example of reading JSON files.
+
+```python
+import pandas as pd
+
+df = pd.read_json("data.json")
+```
+
+{% /tab %}
+
+{% tab name="CSV" %}
+
+This is an example of reading CSV files.
+
+```python
+import pandas as pd
+
+df = pd.read_csv("data.csv")
+```
+
+{% /tab %}
+
+{% /tabs %}
+````

--- a/docs/luma.yaml
+++ b/docs/luma.yaml
@@ -25,3 +25,4 @@ navigation:
   - section: Components
     contents:
       - components/callouts.md
+      - components/tabs.md

--- a/src/luma/app/components/Tabs.module.css
+++ b/src/luma/app/components/Tabs.module.css
@@ -1,0 +1,46 @@
+div.tabs {
+  margin-bottom: 1rem;
+}
+
+div.tabButtons {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e5e7eb;
+  margin-bottom: 1rem;
+}
+
+button.tabButton {
+  background: none;
+  border: none;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 1.5rem;
+  font-weight: 500;
+  color: #6b7280;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+button.tabButton:hover {
+  color: #111827;
+}
+
+button.tabButton.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+}
+
+div.tabContent {
+  padding: 0;
+}
+
+div.tabContent :global(p:first-child) {
+  margin-top: 0;
+}
+
+div.tabContent :global(p:last-child) {
+  margin-bottom: 0;
+}

--- a/src/luma/app/components/Tabs.module.css
+++ b/src/luma/app/components/Tabs.module.css
@@ -14,7 +14,7 @@ button.tabButton {
   border: none;
   padding: 8px 16px;
   cursor: pointer;
-  font-size: 1.5rem;
+  font-size: var(--font-size-paragraph);
   font-weight: 500;
   color: #6b7280;
   border-bottom: 2px solid transparent;
@@ -29,8 +29,8 @@ button.tabButton:hover {
 }
 
 button.tabButton.active {
-  color: #2563eb;
-  border-bottom-color: #2563eb;
+  color: var(--primary-color);
+  border-bottom-color: var(--primary-color);
 }
 
 div.tabContent {

--- a/src/luma/app/components/Tabs.tsx
+++ b/src/luma/app/components/Tabs.tsx
@@ -20,7 +20,7 @@ export function Tabs({ children }: TabsProps) {
   // Extract tab information from children
   const tabs = React.Children.toArray(children).filter(
     (child): child is React.ReactElement<TabProps> =>
-      React.isValidElement(child) && child.type === Tab
+      React.isValidElement(child) && child.type === Tab,
   );
 
   if (tabs.length === 0) {

--- a/src/luma/app/components/Tabs.tsx
+++ b/src/luma/app/components/Tabs.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import styles from "./Tabs.module.css";
+
+interface TabProps {
+  name: string;
+  children: React.ReactNode;
+}
+
+export function Tab({ children }: TabProps) {
+  return <>{children}</>;
+}
+
+interface TabsProps {
+  children: React.ReactNode;
+}
+
+export function Tabs({ children }: TabsProps) {
+  const [activeTab, setActiveTab] = React.useState(0);
+
+  // Extract tab information from children
+  const tabs = React.Children.toArray(children).filter(
+    (child): child is React.ReactElement<TabProps> =>
+      React.isValidElement(child) && child.type === Tab
+  );
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.tabs}>
+      <div className={styles.tabButtons}>
+        {tabs.map((tab, index) => (
+          <button
+            key={index}
+            className={`${styles.tabButton} ${
+              activeTab === index ? styles.active : ""
+            }`}
+            onClick={() => setActiveTab(index)}
+          >
+            {tab.props.name}
+          </button>
+        ))}
+      </div>
+      <div className={styles.tabContent}>{tabs[activeTab]}</div>
+    </div>
+  );
+}

--- a/src/luma/app/components/index.js
+++ b/src/luma/app/components/index.js
@@ -4,3 +4,4 @@ export * from "./CrossRef";
 export * from "./Heading";
 export * from "./SideNav";
 export * from "./TableOfContents";
+export * from "./Tabs";

--- a/src/luma/app/markdoc/tags/index.ts
+++ b/src/luma/app/markdoc/tags/index.ts
@@ -1,1 +1,2 @@
 export * from "./callout.markdoc";
+export * from "./tabs.markdoc";

--- a/src/luma/app/markdoc/tags/tabs.markdoc.ts
+++ b/src/luma/app/markdoc/tags/tabs.markdoc.ts
@@ -1,0 +1,17 @@
+import { Tabs, Tab } from "../../components";
+
+export const tabs = {
+  render: Tabs,
+  children: ["paragraph", "tag", "list"],
+};
+
+export const tab = {
+  render: Tab,
+  children: ["paragraph", "tag", "list"],
+  attributes: {
+    name: {
+      type: String,
+      required: true,
+    },
+  },
+};

--- a/src/luma/app/markdoc/tags/tabs.markdoc.ts
+++ b/src/luma/app/markdoc/tags/tabs.markdoc.ts
@@ -2,12 +2,12 @@ import { Tabs, Tab } from "../../components";
 
 export const tabs = {
   render: Tabs,
-  children: ["paragraph", "tag", "list"],
+  children: ["tag"],
 };
 
 export const tab = {
   render: Tab,
-  children: ["paragraph", "tag", "list"],
+  children: ["paragraph", "fence", "list"],
   attributes: {
     name: {
       type: String,

--- a/src/luma/app/styles/globals.css
+++ b/src/luma/app/styles/globals.css
@@ -8,6 +8,7 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 590;
   --font-weight-bold: 600;
+  --font-size-paragraph: 1.5rem;
   --color-text-primary: #282a31;
   --color-text-tertiary: rgba(75, 85, 99, 1);
   --color-link-primary: #0070f3;
@@ -30,6 +31,7 @@ body {
 
 p,
 li {
+  font-size: var(--font-size-paragraph);
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
## Summary

- Add new `tabs` and `tab` Markdoc tags for organizing content into tabbed panels
- Create React components with state management for tab switching
- Add styling with active states and hover effects
- Include documentation page with examples at `/components/tabs`

## Implementation

**New Files:**
- `src/luma/app/components/Tabs.tsx` - React components for Tabs and Tab
- `src/luma/app/components/Tabs.module.css` - Styling for tabs interface
- `src/luma/app/markdoc/tags/tabs.markdoc.ts` - Markdoc tag definitions
- `docs/components/tabs.md` - Documentation and examples

**Modified Files:**
- `src/luma/app/components/index.js` - Export Tabs components
- `src/luma/app/markdoc/tags/index.ts` - Export tabs tags
- `docs/luma.yaml` - Add tabs page to navigation

## Usage Example

```
{% tabs %}

{% tab name="Parquet" %}
Read Parquet files with pandas.
{% /tab %}

{% tab name="JSON" %}
Read JSON files with pandas.
{% /tab %}

{% /tabs %}
```