### PR TITLE
Standardize font sizing using CSS variables

### DIFF
--- a/src/luma/app/components/Tabs.module.css
+++ b/src/luma/app/components/Tabs.module.css
@@ -14,7 +14,7 @@ button.tabButton {
   border: none;
   padding: 8px 16px;
   cursor: pointer;
-  font-size: var(--font-size-paragraph);
+  font-size: var(--font-size-base);
   font-weight: 500;
   color: #6b7280;
   border-bottom: 2px solid transparent;

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -159,7 +159,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
             overflow: auto;
             flex-grow: 1;
             height: 100vh;
-            font-size: 16px;
+            font-size: var(--font-size-base);
           }
           .container {
             position: relative;

--- a/src/luma/app/styles/globals.css
+++ b/src/luma/app/styles/globals.css
@@ -8,7 +8,7 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 590;
   --font-weight-bold: 600;
-  --font-size-paragraph: 1.5rem;
+  --font-size-base: 1rem;
   --color-text-primary: #282a31;
   --color-text-tertiary: rgba(75, 85, 99, 1);
   --color-link-primary: #0070f3;
@@ -31,7 +31,6 @@ body {
 
 p,
 li {
-  font-size: var(--font-size-paragraph);
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
- Renamed CSS variable from `--font-size-paragraph` (1.5rem) to `--font-size-base` (1rem) for more appropriate base font sizing
- Replaced hardcoded `font-size: 16px` with the CSS variable in `_app.tsx` for consistency
- Updated Tabs component to use the standardized CSS variable
- Removed redundant font-size declaration from paragraph and list item selectors
