### PR TITLE
Add tabbed navigation support

### DIFF
--- a/docs/luma.yaml
+++ b/docs/luma.yaml
@@ -6,16 +6,21 @@ socials:
   - discord: https://discord.gg/yT9KPAddxw
 
 navigation:
-  - tab: User guide
-    contents:
-      - overview.md
+  - overview.md
 
-  - tab: API Reference
+  - section: Showcase
     contents:
-      - section: Showcase
-        contents:
-          - link: https://requests.luma-docs.org/
-            title: requests
+      - link: https://requests.luma-docs.org/
+        title: requests
+
+  - section: Write your docs
+    contents:
+      - how-to/add-a-page.md
+      - how-to/add-a-section.md
+      - how-to/add-an-api-reference.md
+      - how-to/customize-the-favicon.md
+      - how-to/link-to-an-api.md
+      - how-to/publish-your-docs.md
 
   - section: Components
     contents:

--- a/docs/luma.yaml
+++ b/docs/luma.yaml
@@ -6,21 +6,16 @@ socials:
   - discord: https://discord.gg/yT9KPAddxw
 
 navigation:
-  - overview.md
-
-  - section: Showcase
+  - tab: User guide
     contents:
-      - link: https://requests.luma-docs.org/
-        title: requests
+      - overview.md
 
-  - section: Write your docs
+  - tab: API Reference
     contents:
-      - how-to/add-a-page.md
-      - how-to/add-a-section.md
-      - how-to/add-an-api-reference.md
-      - how-to/customize-the-favicon.md
-      - how-to/link-to-an-api.md
-      - how-to/publish-your-docs.md
+      - section: Showcase
+        contents:
+          - link: https://requests.luma-docs.org/
+            title: requests
 
   - section: Components
     contents:

--- a/src/luma/app/components/SideNav.module.css
+++ b/src/luma/app/components/SideNav.module.css
@@ -8,7 +8,7 @@ nav.container {
   height: 100vh;
   padding: 1.5rem 1rem 1rem;
   border-right: 1px solid var(--border-color);
-  min-width: 15rem;
+  min-width: var(--sidenav-width);
 }
 
 span.sectionTitle {

--- a/src/luma/app/components/SideNav.tsx
+++ b/src/luma/app/components/SideNav.tsx
@@ -23,22 +23,22 @@ function SideNavLink({
   key: string;
 }) {
   const router = useRouter();
+  const currentPath = router.asPath.split('#')[0].split('?')[0];
 
   let href: string;
   let isActive: boolean;
   let linkText: string;
   if (item.type == "page") {
     href = `/${item.path.slice(0, -3)}`;
-    isActive = router.asPath === href;
+    isActive = currentPath === href;
     linkText = item.title;
   } else if (item.type == "link") {
     href = item.href;
     isActive = false;
     linkText = item.title;
   } else if (item.type == "reference") {
-    const safe = item.title.toLowerCase().replace(/ /g, "-");
-    href = `/${safe}`;
-    isActive = router.asPath === href;
+    href = `/${item.relative_path.slice(0, -3)}`;
+    isActive = currentPath === href;
     linkText = item.title;
   } else {
     return null;

--- a/src/luma/app/components/SideNav.tsx
+++ b/src/luma/app/components/SideNav.tsx
@@ -12,7 +12,6 @@ import {
 
 interface SideNavProps {
   items: NavigationItem[];
-  usingTabs?: boolean;
 }
 
 function SideNavLink({
@@ -23,7 +22,7 @@ function SideNavLink({
   key: string;
 }) {
   const router = useRouter();
-  const currentPath = router.asPath.split('#')[0].split('?')[0];
+  const currentPath = router.asPath.split("#")[0].split("?")[0];
 
   let href: string;
   let isActive: boolean;
@@ -53,7 +52,7 @@ function SideNavLink({
   );
 }
 
-export function SideNav({ items, usingTabs }: SideNavProps) {
+export function SideNav({ items }: SideNavProps) {
   return (
     <nav className={styles.container}>
       <ul className={`${styles.sidenav}`}>

--- a/src/luma/app/components/SideNav.tsx
+++ b/src/luma/app/components/SideNav.tsx
@@ -12,6 +12,7 @@ import {
 
 interface SideNavProps {
   items: NavigationItem[];
+  usingTabs?: boolean;
 }
 
 function SideNavLink({
@@ -52,7 +53,7 @@ function SideNavLink({
   );
 }
 
-export function SideNav({ items }: SideNavProps) {
+export function SideNav({ items, usingTabs }: SideNavProps) {
   return (
     <nav className={styles.container}>
       <ul className={`${styles.sidenav}`}>
@@ -62,22 +63,24 @@ export function SideNav({ items }: SideNavProps) {
           }
           if (item.type == "section") {
             return (
-              <div key={`section-${itemIndex}`}>
+              <li key={`section-${itemIndex}`}>
                 <span
                   className={styles.sectionTitle}
                   style={{ paddingTop: itemIndex === 0 ? "0" : "1rem" }}
                 >
                   {item.title}
                 </span>
-                {item.contents.map((subitem, subitemIndex) => {
-                  return (
-                    <SideNavLink
-                      item={subitem}
-                      key={`section-${itemIndex}-content-${subitemIndex}`}
-                    />
-                  );
-                })}
-              </div>
+                <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                  {item.contents.map((subitem, subitemIndex) => {
+                    return (
+                      <SideNavLink
+                        item={subitem}
+                        key={`section-${itemIndex}-content-${subitemIndex}`}
+                      />
+                    );
+                  })}
+                </ul>
+              </li>
             );
           }
         })}

--- a/src/luma/app/components/TopNav.module.css
+++ b/src/luma/app/components/TopNav.module.css
@@ -1,0 +1,40 @@
+nav.container {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: var(--topnav-height);
+  background: white;
+  border-bottom: 1px solid var(--border-color);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.tabList {
+  display: flex;
+  gap: 1.5rem;
+  padding: 0 2rem;
+  align-items: center;
+  height: 100%;
+}
+
+a.tab {
+  font-size: 14px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  transition: color 0.2s;
+}
+
+a.tab:hover {
+  color: var(--color-text-primary);
+}
+
+a.tabActive {
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-bold);
+}

--- a/src/luma/app/components/TopNav.tsx
+++ b/src/luma/app/components/TopNav.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import Link from "next/link";
+import styles from "./TopNav.module.css";
+import { Tab, NavigationItem, Page, Reference, Section } from "../types/config";
+
+interface TopNavProps {
+  tabs: Tab[];
+  activeTabIndex: number;
+}
+
+function getFirstPagePath(items: NavigationItem[]): string | null {
+  for (const item of items) {
+    if (item.type === "page") {
+      return `/${item.path.slice(0, -3)}`;
+    } else if (item.type === "section") {
+      const path = getFirstPagePath(item.contents);
+      if (path) return path;
+    } else if (item.type === "reference") {
+      return `/${item.relative_path.slice(0, -3)}`;
+    }
+  }
+  return null;
+}
+
+export function TopNav({ tabs, activeTabIndex }: TopNavProps) {
+  return (
+    <nav className={styles.container}>
+      <div className={styles.tabList}>
+        {tabs.map((tab, index) => {
+          const firstPagePath = getFirstPagePath(tab.contents);
+          const isActive = index === activeTabIndex;
+
+          if (!firstPagePath) {
+            return null;
+          }
+
+          return (
+            <Link
+              key={index}
+              href={firstPagePath}
+              className={`${styles.tab} ${isActive ? styles.tabActive : ""}`}
+            >
+              {tab.title}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/luma/app/components/TopNav.tsx
+++ b/src/luma/app/components/TopNav.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import styles from "./TopNav.module.css";
-import { Tab, NavigationItem, Page, Reference, Section } from "../types/config";
+import { Tab, NavigationItem } from "../types/config";
 
 interface TopNavProps {
   tabs: Tab[];

--- a/src/luma/app/components/index.js
+++ b/src/luma/app/components/index.js
@@ -5,3 +5,4 @@ export * from "./Heading";
 export * from "./SideNav";
 export * from "./TableOfContents";
 export * from "./Tabs";
+export * from "./TopNav";

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -117,7 +117,8 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   // Determine if we're using tabs
   const usingTabs = config?.navigation && hasTabs(config.navigation);
   const tabs = usingTabs ? (config.navigation as Tab[]) : [];
-  const activeTabIndex = usingTabs ? findActiveTabIndex(tabs, router.asPath) : 0;
+  const currentPath = router.asPath.split('#')[0].split('?')[0];
+  const activeTabIndex = usingTabs ? findActiveTabIndex(tabs, currentPath) : 0;
   const sideNavItems = usingTabs
     ? tabs[activeTabIndex]?.contents || []
     : config?.navigation || [];

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -35,10 +35,7 @@ function hasTabs(navigation: NavigationItem[]): boolean {
   return navigation.length > 0 && navigation[0].type === "tab";
 }
 
-function findActiveTabIndex(
-  tabs: Tab[],
-  currentPath: string,
-): number {
+function findActiveTabIndex(tabs: Tab[], currentPath: string): number {
   function pathMatchesItem(item: NavigationItem, path: string): boolean {
     if (item.type === "page") {
       const pagePath = `/${item.path.slice(0, -3)}`;
@@ -117,7 +114,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   // Determine if we're using tabs
   const usingTabs = config?.navigation && hasTabs(config.navigation);
   const tabs = usingTabs ? (config.navigation as Tab[]) : [];
-  const currentPath = router.asPath.split('#')[0].split('?')[0];
+  const currentPath = router.asPath.split("#")[0].split("?")[0];
   const activeTabIndex = usingTabs ? findActiveTabIndex(tabs, currentPath) : 0;
   const sideNavItems = usingTabs
     ? tabs[activeTabIndex]?.contents || []
@@ -167,27 +164,27 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         <link rel="icon" href={faviconHref} />
       </Head>
       <div className="page">
-        <SideNav items={sideNavItems} usingTabs={usingTabs} />
+        <SideNav items={sideNavItems} />
         <div className="main-wrapper">
           {usingTabs && <TopNav tabs={tabs} activeTabIndex={activeTabIndex} />}
           <main className="main">
             <div className="container">
-            <div className="content">
-              <div className="content-wrapper">
-                <Component {...pageProps} />
+              <div className="content">
+                <div className="content-wrapper">
+                  <Component {...pageProps} />
+                </div>
+                <Footer socials={config?.socials} />
               </div>
-              <Footer socials={config?.socials} />
+              {validTocItems.length > 1 ? (
+                <TableOfContents toc={validTocItems} />
+              ) : (
+                <div className="toc-placeholder" />
+              )}
             </div>
-            {validTocItems.length > 1 ? (
-              <TableOfContents toc={validTocItems} />
-            ) : (
-              <div className="toc-placeholder" />
+            {process.env.NEXT_PUBLIC_RELEASE_VERSION != null && (
+              <VersionSelector />
             )}
-          </div>
-          {process.env.NEXT_PUBLIC_RELEASE_VERSION != null && (
-            <VersionSelector />
-          )}
-        </main>
+          </main>
         </div>
       </div>
       <style jsx>

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 
 import { SideNav, TableOfContents } from "../components";
+import { TopNav } from "../components/TopNav";
 import { Footer } from "../components/Footer";
 import VersionSelector from "../components/VersionSelector";
 import "prismjs";
@@ -25,10 +26,40 @@ import type { MarkdocNextJsPageProps } from "@markdoc/next.js";
 import { RenderableTreeNodes, Tag } from "@markdoc/markdoc";
 
 import configData from "../data/config.json";
-import { Config } from "../types/config";
+import { Config, Tab, NavigationItem } from "../types/config";
 const config = configData as Config;
 
 import { TableOfContentsItem } from "../components/TableOfContents";
+
+function hasTabs(navigation: NavigationItem[]): boolean {
+  return navigation.length > 0 && navigation[0].type === "tab";
+}
+
+function findActiveTabIndex(
+  tabs: Tab[],
+  currentPath: string,
+): number {
+  function pathMatchesItem(item: NavigationItem, path: string): boolean {
+    if (item.type === "page") {
+      const pagePath = `/${item.path.slice(0, -3)}`;
+      return path === pagePath;
+    } else if (item.type === "reference") {
+      const refPath = `/${item.relative_path.slice(0, -3)}`;
+      return path === refPath;
+    } else if (item.type === "section") {
+      return item.contents.some((subitem) => pathMatchesItem(subitem, path));
+    }
+    return false;
+  }
+
+  for (let i = 0; i < tabs.length; i++) {
+    if (tabs[i].contents.some((item) => pathMatchesItem(item, currentPath))) {
+      return i;
+    }
+  }
+
+  return 0; // Default to first tab
+}
 
 function collectHeadings(
   node: RenderableTreeNodes,
@@ -83,6 +114,14 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
     };
   }, [router]);
 
+  // Determine if we're using tabs
+  const usingTabs = config?.navigation && hasTabs(config.navigation);
+  const tabs = usingTabs ? (config.navigation as Tab[]) : [];
+  const activeTabIndex = usingTabs ? findActiveTabIndex(tabs, router.asPath) : 0;
+  const sideNavItems = usingTabs
+    ? tabs[activeTabIndex]?.contents || []
+    : config?.navigation || [];
+
   // The Luma CLI should copy the user-provided favicon to 'favicon.ico' in the public
   // directory. If no favicon is provided, use the default favicon.
   const faviconHref = config?.favicon
@@ -127,9 +166,11 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
         <link rel="icon" href={faviconHref} />
       </Head>
       <div className="page">
-        <SideNav items={config?.navigation || []} />
-        <main className="main">
-          <div className="container">
+        <SideNav items={sideNavItems} usingTabs={usingTabs} />
+        <div className="main-wrapper">
+          {usingTabs && <TopNav tabs={tabs} activeTabIndex={activeTabIndex} />}
+          <main className="main">
+            <div className="container">
             <div className="content">
               <div className="content-wrapper">
                 <Component {...pageProps} />
@@ -146,6 +187,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
             <VersionSelector />
           )}
         </main>
+        </div>
       </div>
       <style jsx>
         {`
@@ -154,6 +196,12 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
             display: flex;
             width: 100vw;
             flex-grow: 1;
+          }
+          .main-wrapper {
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+            overflow: hidden;
           }
           .main {
             overflow: auto;
@@ -176,7 +224,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
             padding-top: 48px;
             display: flex;
             flex-direction: column;
-            min-height: calc(100vh - 48px - 96px - 4rem);
+            min-height: calc(100% - 48px - 96px - 4rem);
           }
           .content-wrapper {
             flex: 1 0 auto;

--- a/src/luma/app/pages/index.tsx
+++ b/src/luma/app/pages/index.tsx
@@ -25,6 +25,8 @@ function getFirstPage(navigation: NavigationItem[]): string {
       return `/${item.path.slice(0, -3)}`;
     } else if (item.type == "section") {
       return getFirstPage(item.contents);
+    } else if (item.type == "tab") {
+      return getFirstPage(item.contents);
     } else if (item.type == "reference") {
       return item.relative_path;
     }

--- a/src/luma/app/styles/globals.css
+++ b/src/luma/app/styles/globals.css
@@ -13,6 +13,8 @@
   --color-text-tertiary: rgba(75, 85, 99, 1);
   --color-link-primary: #0070f3;
   --color-link-hover: #0056b3;
+  --topnav-height: 3rem;
+  --sidenav-width: 15rem;
 }
 
 *,
@@ -46,6 +48,7 @@ h1,
 h2,
 h3 {
   font-weight: var(--font-weight-semibold);
+  scroll-margin-top: var(--topnav-height);
 }
 
 a {

--- a/src/luma/app/types/config.tsx
+++ b/src/luma/app/types/config.tsx
@@ -23,7 +23,13 @@ export interface Section {
   contents: (Page | Reference | Link)[];
 }
 
-export type NavigationItem = Page | Reference | Section | Link;
+export interface Tab {
+  type: "tab";
+  title: string;
+  contents: (Page | Reference | Section | Link)[];
+}
+
+export type NavigationItem = Page | Reference | Section | Link | Tab;
 
 export interface Social {
   platform: string;

--- a/src/luma/config/__init__.py
+++ b/src/luma/config/__init__.py
@@ -1,5 +1,14 @@
 """Configuration models and utilities for Luma."""
 
+from .resolution import resolve_config, resolve_page
+from .resolved_config import (
+    ResolvedConfig,
+    ResolvedLink,
+    ResolvedPage,
+    ResolvedReference,
+    ResolvedSection,
+    ResolvedTab,
+)
 from .user_config import (
     CONFIG_FILENAME,
     Config,
@@ -11,15 +20,6 @@ from .user_config import (
     create_or_update_config,
     load_config,
 )
-from .resolved_config import (
-    ResolvedConfig,
-    ResolvedLink,
-    ResolvedPage,
-    ResolvedReference,
-    ResolvedTab,
-    ResolvedSection,
-)
-from .resolution import resolve_config, resolve_page
 
 __all__ = [
     # User-facing config
@@ -38,6 +38,7 @@ __all__ = [
     "ResolvedPage",
     "ResolvedReference",
     "ResolvedSection",
+    "ResolvedTab",
     # Resolution
     "resolve_config",
     "resolve_page",

--- a/src/luma/config/__init__.py
+++ b/src/luma/config/__init__.py
@@ -16,6 +16,7 @@ from .resolved_config import (
     ResolvedLink,
     ResolvedPage,
     ResolvedReference,
+    ResolvedTab,
     ResolvedSection,
 )
 from .resolution import resolve_config, resolve_page

--- a/src/luma/config/resolution.py
+++ b/src/luma/config/resolution.py
@@ -17,8 +17,9 @@ from .resolved_config import (
     ResolvedReference,
     ResolvedSection,
     ResolvedSocial,
+    ResolvedTab,
 )
-from .user_config import Config, Link, NavigationItem, Page, Reference, Section, Social
+from .user_config import Config, Link, NavigationItem, Page, Reference, Section, Social, Tab
 
 
 def resolve_config(config: Config, project_root: str) -> ResolvedConfig:
@@ -65,6 +66,8 @@ def _resolve_navigation_item(item: NavigationItem, project_root: str):
         return _resolve_section(item, project_root)
     elif isinstance(item, Reference):
         return _resolve_reference(item)
+    elif isinstance(item, Tab):
+        return _resolve_tab(item, project_root)
     else:
         assert False, item
 
@@ -101,6 +104,22 @@ def _resolve_section(section: Section, project_root: str) -> ResolvedSection:
         _resolve_navigation_item(item, project_root) for item in section.contents
     ]
     return ResolvedSection(title=section.section, contents=resolved_contents)
+
+
+def _resolve_tab(tab: Tab, project_root: str) -> ResolvedTab:
+    """Resolve a tab navigation item.
+
+    Args:
+        tab: The tab to resolve
+        project_root: The project root directory
+
+    Returns:
+        The resolved tab with resolved contents
+    """
+    resolved_contents = [
+        _resolve_navigation_item(item, project_root) for item in tab.contents
+    ]
+    return ResolvedTab(title=tab.tab, contents=resolved_contents)
 
 
 def _resolve_reference(reference: Reference) -> ResolvedReference:

--- a/src/luma/config/resolved_config.py
+++ b/src/luma/config/resolved_config.py
@@ -39,10 +39,16 @@ class ResolvedSection(BaseModel):
     contents: List[Union[ResolvedPage, ResolvedReference, ResolvedLink]]
 
 
+class ResolvedTab(BaseModel):
+    type: Literal["tab"] = "tab"
+    title: str
+    contents: List[Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink]]
+
+
 class ResolvedConfig(BaseModel):
     name: str
     favicon: Optional[str] = None
     navigation: List[
-        Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink]
+        Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink, ResolvedTab]
     ]
     socials: Optional[List[ResolvedSocial]] = None

--- a/src/luma/config/user_config.py
+++ b/src/luma/config/user_config.py
@@ -35,7 +35,12 @@ class Section(BaseModel):
     contents: List[Union[Page, Reference, Link]]
 
 
-NavigationItem = Union[Page, Section, Reference, Link]
+class Tab(BaseModel):
+    tab: str
+    contents: List[Union[Page, Section, Reference, Link]]
+
+
+NavigationItem = Union[Page, Section, Reference, Link, Tab]
 
 
 class Config(BaseModel):

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from docstring_parser import Docstring, parse
 
-from .config import ResolvedConfig, ResolvedReference, ResolvedSection
+from .config import ResolvedConfig, ResolvedReference, ResolvedSection, ResolvedTab
 from .models import DocstringExample, PyArg, PyClass, PyFunc, PyObj
 from .node import get_node_root
 from .utils import get_module_and_relative_name, get_obj
@@ -69,10 +69,18 @@ def _list_references_in_config(config: ResolvedConfig) -> Iterable[ResolvedRefer
     for item in config.navigation:
         if isinstance(item, ResolvedReference):
             yield item
-        if isinstance(item, ResolvedSection):
+        elif isinstance(item, ResolvedSection):
             for sub_item in item.contents:
                 if isinstance(sub_item, ResolvedReference):
                     yield sub_item
+        elif isinstance(item, ResolvedTab):
+            for sub_item in item.contents:
+                if isinstance(sub_item, ResolvedReference):
+                    yield sub_item
+                elif isinstance(sub_item, ResolvedSection):
+                    for sub_sub_item in sub_item.contents:
+                        if isinstance(sub_sub_item, ResolvedReference):
+                            yield sub_sub_item
 
 
 def _get_summary_and_desc(parsed: Docstring) -> Tuple[Optional[str], Optional[str]]:
@@ -214,11 +222,11 @@ def _get_param_types(obj: Union[FunctionType, type]) -> Dict[str, Optional[str]]
     
     parameters = {}
 
-    if not isinstance(obj, type):
-        signature = inspect.signature(obj)
+    # if not isinstance(obj, type):
+    #     signature = inspect.signature(obj)
 
-        for param_name, param in signature.parameters.items():
-            if param.annotation.__name__ != "_empty":
-                parameters[param_name] = param.annotation.__name__
+    #     for param_name, param in signature.parameters.items():
+    #         if param.annotation.__name__ != "_empty":
+    #             parameters[param_name] = param.annotation.__name__
 
     return parameters

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -130,9 +130,11 @@ def _parse_func(func: FunctionType, qualname: str) -> PyFunc:
     args = []
     for param in parsed.params:
         args.append(
-            PyArg(name=param.arg_name, 
-                  type=param_types.get(param.arg_name, param.type_name), 
-                  desc=param.description)
+            PyArg(
+                name=param.arg_name,
+                type=param_types.get(param.arg_name, param.type_name),
+                desc=param.description,
+            )
         )
 
     returns = parsed.returns.description if parsed.returns else None
@@ -216,17 +218,17 @@ def _get_param_types(obj: Union[FunctionType, type]) -> Dict[str, Optional[str]]
         obj: The function to parse.
 
     Returns:
-        A dictionary of parameter names mapped to signature type hints. 
+        A dictionary of parameter names mapped to signature type hints.
     """
     assert isinstance(obj, (FunctionType, type)), obj
-    
+
     parameters = {}
 
-    # if not isinstance(obj, type):
-    #     signature = inspect.signature(obj)
+    if not isinstance(obj, type):
+        signature = inspect.signature(obj)
 
-    #     for param_name, param in signature.parameters.items():
-    #         if param.annotation.__name__ != "_empty":
-    #             parameters[param_name] = param.annotation.__name__
+        for param_name, param in signature.parameters.items():
+            if param.annotation.__name__ != "_empty":
+                parameters[param_name] = param.annotation.__name__
 
     return parameters


### PR DESCRIPTION
## Summary
- Add support for tabbed navigation in the top navigation bar
- Tabs allow organizing documentation into high-level sections (e.g., "User guide" vs "API Reference")
- Each tab displays its own sidebar navigation when active
- Automatically routes to the first page within each tab

Closes https://github.com/luma-docs/luma/issues/14

## Changes
- **Frontend (Next.js)**:
  - New `TopNav` component with tab navigation UI
  - Updated `SideNav` to display tab-specific navigation items
  - Modified `_app.tsx` to detect tabs in config and determine active tab based on current route
  - Added CSS variables for layout dimensions (`--topnav-height`, `--sidenav-width`)
  - Fixed scroll positioning for headings with `scroll-margin-top`

- **Backend (Python)**:
  - New `Tab` model in `user_config.py` for YAML configuration
  - New `ResolvedTab` model in `resolved_config.py` for resolved configuration
  - Updated `resolution.py` to handle tab resolution
  - Updated `parser.py` to traverse tabs when finding API references

- **Configuration**:
  - Updated example `luma.yaml` to demonstrate tab usage
  - Navigation can now start with tab items containing nested sections/pages

## Test plan
- [x] Test with tab-based navigation (as in docs/luma.yaml)
- [x] Test with traditional flat navigation (backward compatibility)
- [x] Verify active tab highlighting works correctly when navigating between pages
- [x] Verify sidebar updates when switching between tabs
- [x] Test that API references nested under tabs are properly parsed
- [x] Verify scroll-to-heading anchors work with fixed top nav