### PR TITLE
Support quoted type annotations in parser

### DIFF
--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -228,7 +228,23 @@ def _get_param_types(obj: Union[FunctionType, type]) -> Dict[str, Optional[str]]
         signature = inspect.signature(obj)
 
         for param_name, param in signature.parameters.items():
-            if param.annotation.__name__ != "_empty":
-                parameters[param_name] = param.annotation.__name__
+            annotation = _get_type_annotation(param)
+            if annotation is not None:
+                parameters[param_name] = annotation
 
     return parameters
+
+
+def _get_type_annotation(param: inspect.Parameter) -> Optional[str]:
+    if isinstance(param.annotation, str):
+        annotation = param.annotation
+
+    elif isinstance(param.annotation, type):
+        annotation = param.annotation.__name__
+        if annotation == "_empty":
+            annotation = None
+
+    else:
+        annotation = None
+
+    return annotation

--- a/tests/unit/parsing/test_func.py
+++ b/tests/unit/parsing/test_func.py
@@ -1,6 +1,6 @@
 import pytest
 
-from luma.models import DocstringExample, PyArg, PyObjType
+from luma.models import DocstringExample, PyArg, PyFunc, PyObjType
 from luma.parser import parse_obj
 
 
@@ -169,6 +169,36 @@ def test_returns():
     definition = parse_obj(f, "f")
 
     assert definition.returns == "Something."
+
+
+def test_type_annotation():
+    def f(x: int):
+        """
+
+        Args:
+            x:
+        """
+        pass
+
+    definition = parse_obj(f, qualname="f")
+
+    assert isinstance(definition, PyFunc)
+    assert definition.args[0].type == "int"
+
+
+def test_quoted_type_annotation():
+    def f(x: "int"):
+        """
+
+        Args:
+            x:
+        """
+        pass
+
+    definition = parse_obj(f, qualname="f")
+
+    assert isinstance(definition, PyFunc)
+    assert definition.args[0].type == "int"
 
 
 def test_comprehensive():


### PR DESCRIPTION
## Summary

- Add support for string-quoted type annotations (e.g., `"int"`) in function parameters
- Extract type annotation logic into dedicated `_get_type_annotation()` helper function
- Add unit tests for both regular and quoted type annotations

This change enables the parser to handle forward references and PEP 563 (postponed evaluation of annotations), which are commonly used in Python type hints.

## Test plan

- [x] Added `test_type_annotation()` to verify regular type annotations work correctly
- [x] Added `test_quoted_type_annotation()` to verify string-quoted type annotations are handled
- [x] Run full test suite to ensure no regressions