### PR TITLE
Fix table of contents persistence bug with duplicate headings

### DIFF
--- a/src/luma/app/components/TableOfContents.tsx
+++ b/src/luma/app/components/TableOfContents.tsx
@@ -108,12 +108,12 @@ export function TableOfContents({ toc }: TableOfContentsProps) {
         <span className={styles.headerText}>On this page</span>
       </div>
       <ul className={styles.list}>
-        {toc.map((item) => {
+        {toc.map((item, index) => {
           const href = `#${item.id}`;
           const active = activeId === href;
           return (
             <li
-              key={item.title}
+              key={`${item.id}-${index}`}
               className={[
                 styles.item,
                 active ? styles.active : undefined,


### PR DESCRIPTION
## Summary

Fixes a bug where table of contents entries would persist when navigating between pages if any page contained duplicate heading titles.

## Bug Description

When navigating between documentation pages, if a page had duplicate heading titles (e.g., multiple sections with the same name like "Spam"), the table of contents would show stale entries from the previous page alongside the new page's entries. The IntersectionObserver would also fail to properly track heading visibility.

## Root Cause

The `TableOfContents` component in `src/luma/app/components/TableOfContents.tsx` was using `item.title` as the React key when rendering TOC items:

```tsx
key={item.title}  // ❌ Not unique when duplicate headings exist
```

This caused two issues:

1. **React reconciliation failure**: When pages had duplicate heading titles, React saw multiple elements with the same key, violating React's requirement for unique keys. This caused React to reuse existing DOM elements from the previous page instead of properly replacing them.

2. **Duplicate IDs from Markdoc**: Markdoc's heading ID generator (`heading.markdoc.ts`) converts heading text to IDs by slugifying them (e.g., "Spam" → "spam"), but doesn't handle duplicates by appending suffixes. Multiple headings with identical text get the same ID.

## Solution

Changed the React key to combine both the heading ID and its index position:

```tsx
key={`${item.id}-${index}`}  // ✅ Always unique
```

This ensures React keys are guaranteed to be unique even when:
- Heading titles are duplicated
- Markdoc generates identical IDs for duplicate headings

The fix allows React's reconciliation algorithm to properly update the TOC list when navigating between pages, preventing stale entries from persisting.