### PR TITLE
Fix sidenav width consistency and text wrapping

### DIFF
--- a/src/luma/app/components/SideNav.module.css
+++ b/src/luma/app/components/SideNav.module.css
@@ -8,15 +8,20 @@ nav.container {
   height: 100vh;
   padding: 1.5rem 1rem 1rem;
   border-right: 1px solid var(--border-color);
+  width: var(--sidenav-width);
   min-width: var(--sidenav-width);
+  max-width: var(--sidenav-width);
 }
 
 span.sectionTitle {
   padding: 1rem 0.75rem 0.5rem;
   margin-top: 0.25rem;
-  display: inline-block;
+  display: block;
   color: #282a30;
   font-weight: 600;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 ul.sidenav {
@@ -34,7 +39,10 @@ a.sidenavItem {
   text-decoration: none;
   border-radius: 8px;
   transition: background 0.3s;
-  line-height: 1rem;
+  line-height: 1.3;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 a.sidenavItem:hover {


### PR DESCRIPTION
## Summary
- Fixes sidenav width to remain consistent regardless of link text length
- Adds proper text wrapping with automatic hyphenation for long navigation links
- Improves line spacing for better readability with wrapped text

## Changes
- Enforces fixed width constraints on the navigation container to prevent expansion
- Adds `word-wrap`, `overflow-wrap`, and `hyphens` properties to section titles and links
- Changes section title display to `block` for better wrapping behavior
- Increases link line-height from `1rem` to `1.3` for improved multi-line readability

## Test plan
- [x] Test with short navigation link text (should display normally)
- [x] Test with long navigation link text (should wrap gracefully within fixed width)
- [x] Test with very long words (should hyphenate automatically)
- [x] Verify sidenav maintains 240px (15rem) width in all cases
- [x] Check that hover and active states still work correctly with wrapped text