### PR TITLE
Add styled output code blocks with labels

### DIFF
--- a/src/luma/app/components/CodeBlock.module.css
+++ b/src/luma/app/components/CodeBlock.module.css
@@ -10,6 +10,9 @@
   text-shadow: none;
   border-radius: 4px;
   margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 /* Output code block styling */
@@ -24,6 +27,9 @@
   padding: 1rem;
   margin: 0;
   border-radius: 0 0 4px 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .label {

--- a/src/luma/app/components/CodeBlock.module.css
+++ b/src/luma/app/components/CodeBlock.module.css
@@ -11,3 +11,29 @@
   border-radius: 4px;
   margin: 0;
 }
+
+/* Output code block styling */
+.output {
+  background-color: #474e5b;
+  border-color: #474e5b;
+}
+
+.output pre {
+  background-color: #474e5b;
+  color: #e0e0e0;
+  padding: 1rem;
+  margin: 0;
+  border-radius: 0 0 4px 4px;
+}
+
+.label {
+  background-color: #505864;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #505864;
+  border-radius: 4px 4px 0 0;
+}

--- a/src/luma/app/components/CodeBlock.tsx
+++ b/src/luma/app/components/CodeBlock.tsx
@@ -13,14 +13,16 @@ export function CodeBlock({
   "data-language": language,
 }: CodeBlockProps) {
   const ref = React.useRef(null);
+  const isOutput = language === "output";
 
   React.useEffect(() => {
-    if (ref.current) Prism.highlightElement(ref.current, false);
-  }, [children]);
+    if (ref.current && !isOutput) Prism.highlightElement(ref.current, false);
+  }, [children, isOutput]);
 
   return (
-    <div className={styles.code} aria-live="polite">
-      <pre ref={ref} className={`language-${language}`}>
+    <div className={`${styles.code} ${isOutput ? styles.output : ""}`} aria-live="polite">
+      {isOutput && <div className={styles.label}>Output</div>}
+      <pre ref={ref} className={isOutput ? "" : `language-${language}`}>
         {children}
       </pre>
     </div>

--- a/src/luma/app/components/CodeBlock.tsx
+++ b/src/luma/app/components/CodeBlock.tsx
@@ -20,7 +20,10 @@ export function CodeBlock({
   }, [children, isOutput]);
 
   return (
-    <div className={`${styles.code} ${isOutput ? styles.output : ""}`} aria-live="polite">
+    <div
+      className={`${styles.code} ${isOutput ? styles.output : ""}`}
+      aria-live="polite"
+    >
       {isOutput && <div className={styles.label}>Output</div>}
       <pre ref={ref} className={isOutput ? "" : `language-${language}`}>
         {children}


### PR DESCRIPTION
## Summary
- Adds a new "output" code block type for displaying command/program output
- Output blocks have distinct visual styling to differentiate from code input
- Includes an "OUTPUT" label and darker background color

## Changes
- Adds output-specific CSS styling with darker background (#474e5b vs default)
- Renders "OUTPUT" label at the top of output code blocks
- Skips Prism syntax highlighting for output blocks (plain text display)
- Conditionally applies CSS classes based on `language === "output"`

## Usage
In markdown, use the `output` language identifier:
````markdown
```output
This is example output text
```
````

## Test plan
- [ ] Test regular code blocks still render with syntax highlighting
- [ ] Test output code blocks display with OUTPUT label
- [ ] Test output blocks have darker background (#474e5b)
- [ ] Test output blocks skip syntax highlighting (plain text)
- [ ] Verify styling is consistent across different content lengths