### PR TITLE
Add section breadcrumbs for navigation context

### DIFF
--- a/src/luma/app/components/Breadcrumb.tsx
+++ b/src/luma/app/components/Breadcrumb.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+interface BreadcrumbProps {
+  section: string;
+}
+
+export function Breadcrumb({ section }: BreadcrumbProps) {
+  return (
+    <>
+      <div className="breadcrumb">{section}</div>
+      <style jsx>{`
+        .breadcrumb {
+          color: var(--color-link-primary);
+          font-weight: var(--font-weight-semibold);
+          margin-bottom: 0.5rem;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -39,7 +39,7 @@ function hasTabs(navigation: NavigationItem[]): boolean {
 
 function findCurrentPage(
   navigation: NavigationItem[],
-  currentPath: string
+  currentPath: string,
 ): Page | Reference | null {
   for (const item of navigation) {
     if (item.type === "page") {
@@ -185,7 +185,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
   );
 
   const section = config?.navigation
-    ? findCurrentPage(config.navigation, currentPath)?.section ?? null
+    ? (findCurrentPage(config.navigation, currentPath)?.section ?? null)
     : null;
 
   return (

--- a/src/luma/app/types/config.tsx
+++ b/src/luma/app/types/config.tsx
@@ -2,6 +2,7 @@ export interface Page {
   type: "page";
   title: string;
   path: string;
+  section?: string;
 }
 
 export interface Link {
@@ -15,6 +16,7 @@ export interface Reference {
   title: string;
   relative_path: string;
   apis: string[];
+  section?: string;
 }
 
 export interface Section {

--- a/src/luma/config/resolution.py
+++ b/src/luma/config/resolution.py
@@ -19,7 +19,16 @@ from .resolved_config import (
     ResolvedSocial,
     ResolvedTab,
 )
-from .user_config import Config, Link, NavigationItem, Page, Reference, Section, Social, Tab
+from .user_config import (
+    Config,
+    Link,
+    NavigationItem,
+    Page,
+    Reference,
+    Section,
+    Social,
+    Tab,
+)
 
 
 def resolve_config(config: Config, project_root: str) -> ResolvedConfig:
@@ -33,7 +42,8 @@ def resolve_config(config: Config, project_root: str) -> ResolvedConfig:
         The resolved config with inferred titles and validated references
     """
     resolved_navigation = [
-        _resolve_navigation_item(item, project_root) for item in config.navigation
+        _resolve_navigation_item(item, project_root, section=None)
+        for item in config.navigation
     ]
 
     resolved_socials = None
@@ -48,24 +58,27 @@ def resolve_config(config: Config, project_root: str) -> ResolvedConfig:
     )
 
 
-def _resolve_navigation_item(item: NavigationItem, project_root: str):
+def _resolve_navigation_item(
+    item: NavigationItem, project_root: str, section: Optional[str]
+):
     """Resolve a single navigation item.
 
     Args:
         item: The navigation item to resolve
         project_root: The project root directory
+        section: The section name if this item is inside a section, None otherwise
 
     Returns:
         The resolved navigation item
     """
     if isinstance(item, Page):
-        return resolve_page(item, project_root)
+        return resolve_page(item, project_root, section)
     elif isinstance(item, Link):
         return _resolve_link(item)
     elif isinstance(item, Section):
         return _resolve_section(item, project_root)
     elif isinstance(item, Reference):
-        return _resolve_reference(item)
+        return _resolve_reference(item, section)
     elif isinstance(item, Tab):
         return _resolve_tab(item, project_root)
     else:
@@ -101,7 +114,8 @@ def _resolve_section(section: Section, project_root: str) -> ResolvedSection:
         The resolved section with resolved contents
     """
     resolved_contents = [
-        _resolve_navigation_item(item, project_root) for item in section.contents
+        _resolve_navigation_item(item, project_root, section=section.section)
+        for item in section.contents
     ]
     return ResolvedSection(title=section.section, contents=resolved_contents)
 
@@ -117,16 +131,20 @@ def _resolve_tab(tab: Tab, project_root: str) -> ResolvedTab:
         The resolved tab with resolved contents
     """
     resolved_contents = [
-        _resolve_navigation_item(item, project_root) for item in tab.contents
+        _resolve_navigation_item(item, project_root, section=None)
+        for item in tab.contents
     ]
     return ResolvedTab(title=tab.tab, contents=resolved_contents)
 
 
-def _resolve_reference(reference: Reference) -> ResolvedReference:
+def _resolve_reference(
+    reference: Reference, *, section: Optional[str] = None
+) -> ResolvedReference:
     """Resolve a reference navigation item.
 
     Args:
         reference: The reference to resolve
+        section: The section name if this reference is inside a section, None otherwise
 
     Returns:
         The resolved reference with generated path
@@ -136,15 +154,19 @@ def _resolve_reference(reference: Reference) -> ResolvedReference:
         title=reference.reference,
         relative_path=relative_path,
         apis=reference.apis,
+        section=section,
     )
 
 
-def resolve_page(relative_path: str, project_root: str) -> ResolvedPage:
+def resolve_page(
+    relative_path: str, project_root: str, *, section: Optional[str] = None
+) -> ResolvedPage:
     """Resolve a page navigation item.
 
     Args:
         relative_path: The relative path to the page
         project_root: The project root directory
+        section: The section name if this page is inside a section, None otherwise
 
     Returns:
         The resolved page with inferred title
@@ -159,7 +181,7 @@ def resolve_page(relative_path: str, project_root: str) -> ResolvedPage:
         )
 
     title = _infer_title(local_path)
-    return ResolvedPage(title=title, path=relative_path)
+    return ResolvedPage(title=title, path=relative_path, section=section)
 
 
 def _infer_title(local_path: str) -> str:

--- a/src/luma/config/resolution.py
+++ b/src/luma/config/resolution.py
@@ -72,7 +72,7 @@ def _resolve_navigation_item(
         The resolved navigation item
     """
     if isinstance(item, Page):
-        return resolve_page(item, project_root, section)
+        return resolve_page(item, project_root, section=section)
     elif isinstance(item, Link):
         return _resolve_link(item)
     elif isinstance(item, Section):

--- a/src/luma/config/resolution.py
+++ b/src/luma/config/resolution.py
@@ -78,7 +78,7 @@ def _resolve_navigation_item(
     elif isinstance(item, Section):
         return _resolve_section(item, project_root)
     elif isinstance(item, Reference):
-        return _resolve_reference(item, section)
+        return _resolve_reference(item, section=section)
     elif isinstance(item, Tab):
         return _resolve_tab(item, project_root)
     else:

--- a/src/luma/config/resolved_config.py
+++ b/src/luma/config/resolved_config.py
@@ -18,6 +18,7 @@ class ResolvedPage(BaseModel):
     type: Literal["page"] = "page"
     title: str
     path: str
+    section: Optional[str] = None
 
 
 class ResolvedLink(BaseModel):
@@ -31,6 +32,7 @@ class ResolvedReference(BaseModel):
     title: str
     relative_path: str
     apis: List[str]
+    section: Optional[str] = None
 
 
 class ResolvedSection(BaseModel):
@@ -42,13 +44,17 @@ class ResolvedSection(BaseModel):
 class ResolvedTab(BaseModel):
     type: Literal["tab"] = "tab"
     title: str
-    contents: List[Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink]]
+    contents: List[
+        Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink]
+    ]
 
 
 class ResolvedConfig(BaseModel):
     name: str
     favicon: Optional[str] = None
     navigation: List[
-        Union[ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink, ResolvedTab]
+        Union[
+            ResolvedPage, ResolvedSection, ResolvedReference, ResolvedLink, ResolvedTab
+        ]
     ]
     socials: Optional[List[ResolvedSocial]] = None


### PR DESCRIPTION
## Summary

This PR adds breadcrumb support to show navigation context for pages and references within sections. Instead of tracking the full breadcrumb path, we use a simple `section: Optional[str]` field that stores only the immediate parent section name.

Closes https://github.com/luma-docs/luma/issues/19

## Changes

### Backend (Python)
- Added `section: Optional[str]` field to `ResolvedPage` and `ResolvedReference` models
- Updated resolution logic to pass section names when resolving items inside sections
- Sections set the `section` field for their children; tabs pass `None` (tabs don't become breadcrumbs)

### Frontend (TypeScript)
- Added `section?: string` field to `Page` and `Reference` interfaces
- Created new `Breadcrumb` component to display section names
- Updated `_app.tsx` to find current page and render breadcrumb when a section exists

## Behavior

- Pages/references directly under tabs → No breadcrumb shown
- Pages/references inside sections → Section name shown as breadcrumb
- Simple, clean navigation context without complexity