### PR TITLE
Normalize type annotation formatting in API references

### DIFF
--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -263,7 +263,7 @@ def format_annotation(annotation: Any) -> str:
         name = format_annotation(typing.get_origin(annotation))
         args = [format_annotation(arg) for arg in typing.get_args(annotation)]
         if args:
-            return f"{name}[{", ".join(args)}]"
+            return f"{name}[{', '.join(args)}]"
         else:
             return name
 

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -2,7 +2,8 @@ import inspect
 import json
 import logging
 import os
-from types import FunctionType, GenericAlias
+import typing
+from types import FunctionType
 from typing import Any, Dict, Iterable, Optional, Tuple, Union
 
 from docstring_parser import Docstring, parse
@@ -213,7 +214,7 @@ def format_signature(obj: Union[FunctionType, type], name: str) -> str:
 
         if parameter.annotation != inspect.Signature.empty:
             formatted_parameter = (
-                f"{parameter.name}: {_format_annotation(parameter.annotation)}"
+                f"{parameter.name}: {format_annotation(parameter.annotation)}"
             )
         else:
             formatted_parameter = parameter.name
@@ -226,7 +227,7 @@ def format_signature(obj: Union[FunctionType, type], name: str) -> str:
     # Try single-line signature first.
     formatted_signature = f"{name}({', '.join(formatted_parameters)})"
     if signature.return_annotation != inspect.Signature.empty:
-        formatted_signature += f" -> {_format_annotation(signature.return_annotation)}"
+        formatted_signature += f" -> {format_annotation(signature.return_annotation)}"
 
     # If the signature is too long, wrap it at the commas.
     if len(formatted_signature) > MAX_FORMATTED_SIGNATURE_LENGTH:
@@ -237,25 +238,34 @@ def format_signature(obj: Union[FunctionType, type], name: str) -> str:
 
         if signature.return_annotation != inspect.Signature.empty:
             formatted_signature += (
-                f" -> {_format_annotation(signature.return_annotation)}"
+                f" -> {format_annotation(signature.return_annotation)}"
             )
 
     return formatted_signature
 
 
-def _format_annotation(annotation: Any) -> str:
+def format_annotation(annotation: Any) -> str:
     # If the user provided a quoted type, used that quoted value directly.
     if isinstance(annotation, str):
         return annotation
 
-    # If the annotation looks `list[int]`, the repr looks best.
-    elif isinstance(annotation, GenericAlias):
-        return repr(annotation)
+    elif annotation is type(None):
+        return "None"
 
-    # If the annotation looks like `List[int]`, then the repr contains the `typing`
-    # module.
-    elif repr(annotation).startswith("typing."):
-        return repr(annotation).removeprefix("typing.")
+    elif isinstance(annotation, typing.ForwardRef):
+        # HACK
+        return repr(annotation)[len("ForwardRef('") : -len("']")]
+
+    elif repr(typing.get_origin(annotation)) == "typing.Union":
+        return " | ".join(format_annotation(arg) for arg in typing.get_args(annotation))
+
+    elif typing.get_origin(annotation) is not None:
+        name = format_annotation(typing.get_origin(annotation))
+        args = [format_annotation(arg) for arg in typing.get_args(annotation)]
+        if args:
+            return f"{name}[{", ".join(args)}]"
+        else:
+            return name
 
     elif hasattr(annotation, "__name__"):
         return annotation.__name__

--- a/tests/unit/parsing/test_func.py
+++ b/tests/unit/parsing/test_func.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import Any, List, Optional, Union
 
 import pytest
 
 from luma.models import DocstringExample, PyArg, PyFunc, PyObjType
-from luma.parser import format_signature, parse_obj
+from luma.parser import format_annotation, format_signature, parse_obj
 
 
 def test_name():
@@ -251,13 +251,35 @@ def test_short_signature_is_not_wrapped():
     assert signature == "f(x: int, y: int) -> int"
 
 
+@pytest.mark.parametrize(
+    "annotation, expected_string",
+    [
+        (str, "str"),
+        ("str", "str"),
+        (None, "None"),
+        (list, "list"),
+        (list[int], "list[int]"),
+        (list["int"], "list[int]"),
+        (List, "list"),
+        (List[int], "list[int]"),
+        (List["int"], "list[int]"),
+        (Union[int, str], "int | str"),
+        (Union["int", "str"], "int | str"),
+        (Optional[int], "int | None"),
+    ],
+)
+def test_format_annotation(annotation: Any, expected_string: str):
+    formatted_annotation = format_annotation(annotation)
+    assert formatted_annotation == expected_string
+
+
 def test_signature_with_typing_list():
     def f(x: List[int]):
         return 0
 
     signature = format_signature(f, "f")
 
-    assert signature == "f(x: List[int])"
+    assert signature == "f(x: list[int])"
 
 
 def test_signature_with_builtin_list():


### PR DESCRIPTION
## Summary

The current implementation produces inconsistent formatting for type annotations in API documentation. For example, `typing.List[int]` and `list[int]` render differently, even though they're semantically equivalent in modern Python. Additionally, Union types display as the verbose `Union[int, str]` instead of the more readable PEP 604 pipe syntax `int | str`.

This inconsistency creates confusion for users reading the documentation, as the same concept appears in different forms depending on how the original code was written. It also makes the documentation look outdated, since modern Python (3.10+) encourages the newer syntax.

This PR normalizes all type annotations to use modern, consistent formatting regardless of the input style, ensuring users see clean, uniform type hints throughout the API reference.

## Changes

- Refactored annotation formatting to use `typing.get_origin()` and `typing.get_args()` for robust handling of generic types
- Convert `Union[X, Y]` to `X | Y` pipe syntax for better readability
- Normalize both `typing.List[int]` and `list[int]` to render as `list[int]`
- Add proper handling for forward references and `None` type
- Make `format_annotation()` public with comprehensive test coverage