### PR TITLE
Fix heading overflow in documentation pages

### DIFF
--- a/src/luma/app/styles/globals.css
+++ b/src/luma/app/styles/globals.css
@@ -49,6 +49,8 @@ h2,
 h3 {
   font-weight: var(--font-weight-semibold);
   scroll-margin-top: var(--topnav-height);
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 a {


### PR DESCRIPTION
## Summary

Long headings without natural break points (such as long function names, technical terms, or URLs) were overflowing their containers instead of wrapping, causing layout issues and making content difficult to read on smaller screens.

## Changes

This PR adds `word-wrap: break-word` and `overflow-wrap: break-word` properties to `h1`, `h2`, and `h3` elements to ensure they break appropriately when they exceed container width.

These CSS properties work together to:
- `overflow-wrap: break-word` - Modern standard property that breaks long words at arbitrary points if needed
- `word-wrap: break-word` - Legacy property for older browser support (same behavior as overflow-wrap)

This ensures headings remain readable and don't break the page layout, particularly important for API documentation where long qualified names are common.