### PR TITLE
Automatically linkify bare URLs in documentation content

### DIFF
--- a/src/luma/app/markdoc/nodes/index.ts
+++ b/src/luma/app/markdoc/nodes/index.ts
@@ -3,3 +3,4 @@
 export * from "./fence.markdoc";
 export * from "./heading.markdoc";
 export * from "./link.markdoc";
+export * from "./text.markdoc";

--- a/src/luma/app/markdoc/nodes/link.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/link.markdoc.ts
@@ -1,4 +1,5 @@
 import { CrossRef } from "../../components";
+import { Node, Config, Tag } from "@markdoc/markdoc";
 
 export const link = {
   render: CrossRef,
@@ -6,5 +7,21 @@ export const link = {
     href: {
       type: String,
     },
+  },
+  transform(node: Node, config: Config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+
+    // If text looks like a link (e.g., "https://google.com"), we transform the text
+    // into a Link tag. The problem is that if the text of a Markdown link looks like
+    // a link (e.g., "[https://google.com](https://google.com)"), then we create nested
+    // Link tags, and Next raises an error.
+    //
+    // To prevent this issue, we return nested Link tags directly.
+    if (children[0] instanceof Tag && children[0].name === "Link") {
+      return children[0];
+    }
+
+    return new Tag("Link", { ...attributes }, children);
   },
 };

--- a/src/luma/app/markdoc/nodes/text.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/text.markdoc.ts
@@ -1,0 +1,48 @@
+import { Tag, Node, Config } from "@markdoc/markdoc";
+import { linkifyUrlsToHtml } from "linkify-urls";
+
+export const text = {
+  transform(node: Node, config: Config) {
+    const content = node.attributes.content;
+
+    if (typeof content !== "string") {
+      return content;
+    }
+
+    // Use linkify-urls to convert URLs to HTML
+    const linkedHtml = linkifyUrlsToHtml(content);
+
+    // If no URLs were found, linkifyUrlsToHtml returns the original string
+    if (linkedHtml === content) {
+      return content;
+    }
+
+    // Parse the HTML and convert to Markdoc Tags
+    // The HTML will be in the format: "text <a href="...">url</a> more text"
+    const parts: Array<string | Tag> = [];
+    const anchorRegex = /<a href="([^"]+)">([^<]+)<\/a>/g;
+    let lastIndex = 0;
+    let match;
+
+    while ((match = anchorRegex.exec(linkedHtml)) !== null) {
+      // Add text before the link
+      if (match.index > lastIndex) {
+        parts.push(linkedHtml.substring(lastIndex, match.index));
+      }
+
+      // Add the link as a plain <a> tag for external URLs
+      const href = match[1];
+      const linkText = match[2];
+      parts.push(new Tag("Link", { href }, [linkText]));
+
+      lastIndex = anchorRegex.lastIndex;
+    }
+
+    // Add any remaining text after the last link
+    if (lastIndex < linkedHtml.length) {
+      parts.push(linkedHtml.substring(lastIndex));
+    }
+
+    return parts.length > 0 ? parts : content;
+  },
+};

--- a/src/luma/app/package-lock.json
+++ b/src/luma/app/package-lock.json
@@ -11,6 +11,7 @@
         "@markdoc/markdoc": "^0.4.0",
         "@markdoc/next.js": "^0.3.7",
         "js-yaml": "^4.1.0",
+        "linkify-urls": "^5.0.2",
         "minisearch": "^7.2.0",
         "next": "15.0.4",
         "prismjs": "^1.29.0",
@@ -1373,6 +1374,34 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/create-html-element": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/create-html-element/-/create-html-element-4.0.1.tgz",
+      "integrity": "sha512-K/wr7TGTPh4v2m5JpxNWQ/W4/lHkVjun7rTmg8ycNjbJE0ngjxvVYSiYzgq4iiJ+H5zq2FcPu6ZehCZHHcZtfA==",
+      "dependencies": {
+        "escape-goat": "^4.0.0",
+        "html-tags": "^3.1.0",
+        "stringify-attributes": "^3.0.0",
+        "type-fest": "^2.5.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-html-element/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1752,6 +1781,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2706,6 +2746,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3341,6 +3392,20 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/linkify-urls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-urls/-/linkify-urls-5.2.0.tgz",
+      "integrity": "sha512-nPi06ipEpUZIOML0RSHaD3UR902hQdorXPnA2NNdq8bjRz1Pj7AVfXHrca6MO+jQx8+DhQA3fDqp6XFxHZTwqg==",
+      "dependencies": {
+        "create-html-element": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4745,6 +4810,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-attributes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-attributes/-/stringify-attributes-3.0.0.tgz",
+      "integrity": "sha512-tJKiThlLfog6ljT7ZTihlMh0iAtjKlu/ss9DMmBE5oOosbMqOMcuxc7zDfxP2lGzSb2Bwvbd3gQTqTSCmXyySw==",
+      "dependencies": {
+        "escape-goat": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-attributes/node_modules/escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {

--- a/src/luma/app/package.json
+++ b/src/luma/app/package.json
@@ -12,6 +12,7 @@
     "@markdoc/markdoc": "^0.4.0",
     "@markdoc/next.js": "^0.3.7",
     "js-yaml": "^4.1.0",
+    "linkify-urls": "^5.0.2",
     "minisearch": "^7.2.0",
     "next": "15.0.4",
     "prismjs": "^1.29.0",


### PR DESCRIPTION
## Summary

Documentation content often contains bare URLs (like `https://example.com`) that aren't wrapped in Markdown link syntax. These currently render as plain text, forcing users to manually copy-paste URLs to visit them. This creates a poor user experience, especially for API documentation and technical guides that frequently reference external resources.

This PR adds automatic URL detection and linking through a custom Markdoc text node transformer. When text content contains URLs, they are automatically converted to clickable links using the `linkify-urls` library for robust URL detection.

The implementation also handles a subtle edge case: when a Markdown link's text is itself a URL (e.g., `[https://example.com](https://example.com)`), we prevent nested Link components that would cause Next.js errors by unwrapping the inner link in the link node transformer.

## Changes

- Add new `text.markdoc.ts` node transformer that detects and linkifies bare URLs
- Update `link.markdoc.ts` to prevent nested Link components when link text is a URL
- Add `linkify-urls` dependency for URL detection
- Export the new text node from the nodes index