### PR TITLE
Reduce code snippet font size to prevent line wrapping

### DIFF
--- a/src/luma/app/styles/prism-theme.css
+++ b/src/luma/app/styles/prism-theme.css
@@ -34,6 +34,7 @@ pre[class*="language-"] {
   color: hsl(230, 8%, 24%);
   font-family:
     "Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+  font-size: 14px;
   direction: ltr;
   text-align: left;
   white-space: pre;


### PR DESCRIPTION
## Summary

This change reduces the font size of code snippets from 16px to 14px to minimize unwanted line wrapping in code blocks.

## Why this change is needed

The previous 16px font size frequently caused code lines to wrap within code blocks, creating an awkward and hard-to-read presentation. Wrapped code disrupts visual flow and makes it difficult to parse syntax and structure at a glance—particularly problematic for function signatures, long variable names, or chained method calls.

By reducing to 14px, more characters fit per line, significantly reducing unwanted wrapping while maintaining good readability. This creates a cleaner, more professional appearance for code examples throughout the documentation.