### PR TITLE
Add visual spacing between sections and subsequent pages in sidenav

### DIFF
--- a/src/luma/app/components/SideNav.tsx
+++ b/src/luma/app/components/SideNav.tsx
@@ -18,9 +18,11 @@ interface SideNavProps {
 function SideNavLink({
   item,
   key,
+  addTopSpacing = false,
 }: {
   item: Page | Reference | LinkType;
   key: string;
+  addTopSpacing?: boolean;
 }) {
   const router = useRouter();
   const currentPath = router.asPath.split("#")[0].split("?")[0];
@@ -45,7 +47,10 @@ function SideNavLink({
   }
 
   return (
-    <li className={isActive ? styles.sideNavItemActive : ""}>
+    <li
+      className={isActive ? styles.sideNavItemActive : ""}
+      style={addTopSpacing ? { marginTop: "0.75rem" } : undefined}
+    >
       <Link className={styles.sidenavItem} key={key} href={href}>
         {linkText}
       </Link>
@@ -60,7 +65,15 @@ export function SideNav({ items }: SideNavProps) {
       <ul className={`${styles.sidenav}`}>
         {items.map((item, itemIndex) => {
           if (item.type == "page" || item.type == "reference") {
-            return <SideNavLink item={item} key={`section-${itemIndex}`} />;
+            const previousItemIsSection =
+              itemIndex > 0 && items[itemIndex - 1].type === "section";
+            return (
+              <SideNavLink
+                item={item}
+                key={`section-${itemIndex}`}
+                addTopSpacing={previousItemIsSection}
+              />
+            );
           }
           if (item.type == "section") {
             return (


### PR DESCRIPTION
## Summary

In the documentation sidenav, when a regular page or API reference appears directly after a collapsible section, there's no visual spacing to distinguish it from the section's contents. This creates ambiguity—users can't easily tell whether the page is part of the preceding section or a standalone navigation item.

This change adds a 0.75rem top margin to pages and references that immediately follow sections, creating clear visual separation. The spacing is applied conditionally only in this specific case, so all other sidenav spacing remains unchanged.

This improves navigation clarity and helps users better understand the documentation structure at a glance.