### PR TITLE
Add image support

### DIFF
--- a/src/luma/link.py
+++ b/src/luma/link.py
@@ -9,18 +9,8 @@ from watchdog.observers import Observer
 from .config import ResolvedConfig
 from .node import get_node_root
 
+STATIC_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp", ".gif", ".ico")
 logger = logging.getLogger(__name__)
-
-
-def link_static_asset(relative_path: str, project_root: str):
-    src = os.path.join(project_root, relative_path)
-    dst = os.path.join(get_node_root(project_root), "public", relative_path)
-
-    if os.path.exists(dst):
-        os.remove(dst)
-
-    logger.debug(f"Linking file from '{src}' to '{dst}'")
-    os.link(src, dst)
 
 
 def link_config(resolved_config: ResolvedConfig, project_root: str):
@@ -54,6 +44,31 @@ def _link_page(project_root: str, relative_path: str):
 
     logger.debug(f"Linking page from '{src}' to '{dst}'")
     os.makedirs(os.path.dirname(dst), exist_ok=True)
+    os.link(src, dst)
+
+
+def link_static_assets(project_root: str):
+    for dir_path, _, filenames in os.walk(project_root):
+        for filename in filenames:
+            if not filename.endswith(STATIC_EXTENSIONS):
+                continue
+
+            file_path = os.path.join(dir_path, filename)
+            relative_path = os.path.relpath(file_path, project_root)
+            if relative_path.startswith(".luma"):
+                continue
+
+            _link_static_asset(project_root, relative_path)
+
+
+def _link_static_asset(project_root: str, relative_path: str):
+    src = os.path.join(project_root, relative_path)
+    dst = os.path.join(get_node_root(project_root), "public", relative_path)
+
+    if os.path.exists(dst):
+        os.remove(dst)
+
+    logger.debug(f"Linking file from '{src}' to '{dst}'")
     os.link(src, dst)
 
 

--- a/src/luma/main.py
+++ b/src/luma/main.py
@@ -22,7 +22,7 @@ from .link import (
     link_config,
     link_existing_pages,
     link_page_on_creation,
-    link_static_asset,
+    link_static_assets,
 )
 from .node import get_node_root, is_node_installed, run_node_dev
 from .parser import prepare_references
@@ -63,9 +63,8 @@ def init():
     config = create_or_update_config(project_root, package_name)
     resolved_config = resolve_config(config, project_root=project_root)
     link_config(resolved_config, project_root)
-    if config.favicon:
-        link_static_asset(config.favicon, project_root)
     link_existing_pages(project_root)
+    link_static_assets(project_root)
     build_search_index(project_root, resolved_config)
 
 
@@ -81,9 +80,8 @@ def dev(port: Annotated[Optional[int], typer.Option()] = None):
     link_config(resolved_config, project_root)
     prepare_references(project_root, resolved_config)
 
-    if config.favicon:
-        link_static_asset(config.favicon, project_root)
     link_existing_pages(project_root)
+    link_static_assets(project_root)
     build_search_index(project_root, resolved_config)
     link_page_on_creation(project_root)
 
@@ -103,6 +101,7 @@ def deploy(version: Annotated[Optional[str], typer.Option("--version", "-v")] = 
 
     link_config(resolved_config, project_root)
     link_existing_pages(project_root)
+    link_static_assets(project_root)
     build_search_index(project_root, resolved_config)
 
     try:


### PR DESCRIPTION
Add image support by linking static assets in project root to `public` folder. This also fixes favicons on deployments since those weren't being linked in the `deploy` command previously. Example deployed at https://image-support.luma-docs.org/latest/overview.