### PR TITLE
Improve text wrapping in table of contents for long identifiers

### DIFF
--- a/src/luma/app/components/TableOfContents.module.css
+++ b/src/luma/app/components/TableOfContents.module.css
@@ -36,6 +36,8 @@
   color: var(--text-secondary, #6f6e77);
   transition: color 0.2s ease;
   font-weight: var(--font-weight-medium);
+  overflow-wrap: break-word;
+  hyphens: none;
 }
 
 .link:hover {

--- a/src/luma/app/components/TableOfContents.tsx
+++ b/src/luma/app/components/TableOfContents.tsx
@@ -123,7 +123,7 @@ export function TableOfContents({ toc }: TableOfContentsProps) {
                 .join(" ")}
             >
               <Link href={href} className={styles.link}>
-                {item.title}
+                {item.title.replace(/([._])/g, "$1\u200B")}
               </Link>
             </li>
           );


### PR DESCRIPTION
## Problem

API documentation often includes long Python identifiers in the table of contents (e.g., `requests.post`, `my_very_long_function_name`). Without proper text wrapping, these can overflow their container or create awkward line breaks, making the navigation difficult to read and use.

## Solution

This PR enables intelligent wrapping of long identifiers by:

1. **CSS changes**: Added `overflow-wrap: break-word` and `hyphens: none` to allow text to wrap when necessary without adding hyphens (which would be confusing in code identifiers)

2. **JavaScript changes**: Inserted zero-width spaces (`\u200B`) after dots and underscores in TOC item titles, allowing the browser to break at natural boundaries in identifier names

## Result

Long names like `SomeClass.some_method` will now wrap cleanly at the dot or underscore when space is constrained, while staying together on one line when they fit. This makes the table of contents more readable and maintainable for documentation with long API names.