### PR TITLE
Make Python REPL prompts non-copyable in documentation code blocks

### DIFF
--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -9,18 +9,12 @@ import "prismjs";
 // Import other Prism themes here
 import "prismjs/components/prism-bash.min";
 import "prismjs/components/prism-python.min";
+import "../lib/prism-python-repl"; // Extends Python to tokenize REPL prompts
 import "prismjs/components/prism-yaml.min";
 import "prismjs/components/prism-markdown.min";
 import "../styles/prism-theme.css";
-import { useRouter } from "next/router";
-
-import "prismjs";
-import "prismjs/components/prism-bash.min";
-import "prismjs/components/prism-python.min";
-import "prismjs/components/prism-yaml.min";
-
-import "../styles/prism-theme.css";
 import "../styles/globals.css";
+import { useRouter } from "next/router";
 
 import type { AppProps } from "next/app";
 import type { MarkdocNextJsPageProps } from "@markdoc/next.js";

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -9,7 +9,6 @@ import "prismjs";
 // Import other Prism themes here
 import "prismjs/components/prism-bash.min";
 import "prismjs/components/prism-python.min";
-import "../lib/prism-python-repl"; // Extends Python to tokenize REPL prompts
 import "prismjs/components/prism-yaml.min";
 import "prismjs/components/prism-markdown.min";
 import "../styles/prism-theme.css";

--- a/src/luma/app/styles/prism-theme.css
+++ b/src/luma/app/styles/prism-theme.css
@@ -126,12 +126,21 @@ pre[class*="language-"] {
 
 .token.variable,
 .token.operator,
-.token.function {
+.token.function,
+.token.prompt {
   color: hsl(221, 87%, 60%);
 }
 
 .token.url {
   color: hsl(198, 99%, 37%);
+}
+
+/* Python REPL prompt (>>> and ...) */
+.token.prompt {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 /* HTML overrides */


### PR DESCRIPTION
When users copy Python REPL examples from documentation, they shouldn't have to manually remove the >>> and ... prompts. This is a common pain point that makes it harder to quickly test code snippets.

This change extends Prism's Python syntax highlighting to tokenize REPL prompts as a separate token type, then applies user-select: none CSS to prevent them from being selected when users highlight code. This matches the behavior of other documentation tools like Sphinx and improves the developer experience when working with Python interactive session examples.