### PR TITLE
Add parameter separators in parsed signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+src/luma/app/data/*.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-src/luma/app/data/*.json
-

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -216,6 +216,8 @@ def format_signature(obj: Union[FunctionType, type], name: str) -> str:
         if parameter.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and previous_kind == inspect.Parameter.POSITIONAL_ONLY:
             formatted_parameters.append("/")
         elif parameter.kind == inspect.Parameter.KEYWORD_ONLY and previous_kind != inspect.Parameter.KEYWORD_ONLY:
+            if previous_kind == inspect.Parameter.POSITIONAL_ONLY:
+                formatted_parameters.append("/")
             formatted_parameters.append("*")
             
         previous_kind = parameter.kind

--- a/src/luma/parser.py
+++ b/src/luma/parser.py
@@ -208,9 +208,17 @@ def format_signature(obj: Union[FunctionType, type], name: str) -> str:
     # Build list of formatted parameters, excluding 'self'. Each element is a string
     # of the form 'name: type' or 'name' if no annotation is specified.
     formatted_parameters: list[str] = []
+    previous_kind = None
     for parameter in signature.parameters.values():
         if parameter.name == "self":
             continue
+
+        if parameter.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and previous_kind == inspect.Parameter.POSITIONAL_ONLY:
+            formatted_parameters.append("/")
+        elif parameter.kind == inspect.Parameter.KEYWORD_ONLY and previous_kind != inspect.Parameter.KEYWORD_ONLY:
+            formatted_parameters.append("*")
+            
+        previous_kind = parameter.kind
 
         if parameter.annotation != inspect.Signature.empty:
             formatted_parameter = (

--- a/tests/unit/parsing/test_func.py
+++ b/tests/unit/parsing/test_func.py
@@ -318,3 +318,42 @@ def test_long_signature_wraps_at_commas():
         ") -> int"
     )
     assert signature == expected_signature
+
+
+def test_positional_and_keyword():
+    def f(
+        positional_parameter: int,
+        /,
+        positional_or_keyword_parameter: str,
+        *,
+        keyword_parameter: float,
+    ) -> int:
+        return 0
+
+    signature = format_signature(f, "f")
+
+    expected_signature = (
+        "f(\n"
+        "    positional_parameter: int,\n"
+        "    /,\n"
+        "    positional_or_keyword_parameter: str,\n"
+        "    *,\n"
+        "    keyword_parameter: float,\n"
+        ") -> int"
+    )
+    assert signature == expected_signature
+
+def test_keyword_only():
+    def f(
+        *,
+        keyword_parameter: int,
+        another_keyword_parameter: str,
+    ) -> int:
+        return 0
+
+    signature = format_signature(f, "f")
+
+    expected_signature = (
+        "f(*, keyword_parameter: int, another_keyword_parameter: str) -> int"
+    )
+    assert signature == expected_signature

--- a/tests/unit/parsing/test_func.py
+++ b/tests/unit/parsing/test_func.py
@@ -343,6 +343,7 @@ def test_positional_and_keyword():
     )
     assert signature == expected_signature
 
+
 def test_keyword_only():
     def f(
         *,
@@ -355,5 +356,22 @@ def test_keyword_only():
 
     expected_signature = (
         "f(*, keyword_parameter: int, another_keyword_parameter: str) -> int"
+    )
+    assert signature == expected_signature
+
+
+def test_positional_and_keyword_only():
+    def f(
+        positional_parameter: int,
+        /,
+        *,
+        keyword_parameter: str,
+    ) -> int:
+        return 0
+
+    signature = format_signature(f, "f")
+
+    expected_signature = (
+        "f(positional_parameter: int, /, *, keyword_parameter: str) -> int"
     )
     assert signature == expected_signature


### PR DESCRIPTION
Check for `/` and `*` separators and display in parsed signatures:

<img width="665" height="180" alt="Screenshot 2025-12-14 at 5 59 18 PM" src="https://github.com/user-attachments/assets/68e95291-3e41-4ddb-a3a8-be5e75738728" />