### PR TITLE
Fix null socials handling

### DIFF
--- a/src/luma/app/components/Footer.tsx
+++ b/src/luma/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import styles from "./Footer.module.css";
 import { Social } from "../types/config";
 
 interface FooterProps {
-  socials: Social[] | null;
+  socials?: Social[] | null;
 }
 
 const ICONS = {

--- a/src/luma/app/components/Footer.tsx
+++ b/src/luma/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import styles from "./Footer.module.css";
 import { Social } from "../types/config";
 
 interface FooterProps {
-  socials?: Social[];
+  socials: Social[] | null;
 }
 
 const ICONS = {

--- a/src/luma/app/components/Footer.tsx
+++ b/src/luma/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import styles from "./Footer.module.css";
 import { Social } from "../types/config";
 
 interface FooterProps {
-  socials?: Social[];
+  socials?: Social[] | null;
 }
 
 const ICONS = {

--- a/src/luma/app/components/Footer.tsx
+++ b/src/luma/app/components/Footer.tsx
@@ -2,7 +2,7 @@ import styles from "./Footer.module.css";
 import { Social } from "../types/config";
 
 interface FooterProps {
-  socials?: Social[] | null;
+  socials?: Social[];
 }
 
 const ICONS = {

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -203,7 +203,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
                   {section && <Breadcrumb section={section} />}
                   <Component {...pageProps} />
                 </div>
-                <Footer socials={config.socials} />
+                <Footer socials={config?.socials} />
               </div>
               {validTocItems.length > 1 ? (
                 <TableOfContents toc={validTocItems} />

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -203,7 +203,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
                   {section && <Breadcrumb section={section} />}
                   <Component {...pageProps} />
                 </div>
-                <Footer socials={config?.socials ?? undefined} />
+                <Footer socials={config.socials} />
               </div>
               {validTocItems.length > 1 ? (
                 <TableOfContents toc={validTocItems} />

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -203,7 +203,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
                   {section && <Breadcrumb section={section} />}
                   <Component {...pageProps} />
                 </div>
-                <Footer socials={config?.socials} />
+                <Footer socials={config?.socials ?? undefined} />
               </div>
               {validTocItems.length > 1 ? (
                 <TableOfContents toc={validTocItems} />

--- a/src/luma/app/types/config.tsx
+++ b/src/luma/app/types/config.tsx
@@ -42,5 +42,5 @@ export interface Config {
   name: string;
   favicon: string | null;
   navigation: NavigationItem[];
-  socials?: Social[];
+  socials: Social[] | null;
 }

--- a/src/luma/app/types/config.tsx
+++ b/src/luma/app/types/config.tsx
@@ -42,5 +42,5 @@ export interface Config {
   name: string;
   favicon: string | null;
   navigation: NavigationItem[];
-  socials: Social[] | null;
+  socials?: Social[] | null;
 }


### PR DESCRIPTION
Add `null` type to `Socials` since missing JSON field deserializes to `null`. I'm able to deploy locally, so this will fix the deployment error from the CI:
```
   Linting and checking validity of types ...
Failed to compile.
./pages/_app.tsx:24:16
Type error: Conversion of type '{ name: string; favicon: null; navigation: ({ type: string; title: string; path: string; section: null; contents?: undefined; } | { type: string; title: string; contents: ({ type: string; title: string; relative_path: string; apis: string[]; section: string; path?: undefined; } | { ...; })[]; path?: undefined; secti...' to type 'Config' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Types of property 'socials' are incompatible.
    Type 'null' is not comparable to type 'Social[] | undefined'.
  22 | import configData from "../data/config.json";
  23 | import { Config, Tab, NavigationItem } from "../types/config";
> 24 | const config = configData as Config;
     |                ^
  25 |
  26 | import { TableOfContentsItem } from "../components/TableOfContents";
  27 | import { Page, Reference } from "../types/config";
Error: Command "npm run build" exited with 1
```