### PR TITLE
Fix crash when linking static assets in nested directories

### DIFF
--- a/src/luma/link.py
+++ b/src/luma/link.py
@@ -84,6 +84,7 @@ def _link_static_asset(project_root: str, relative_path: str):
         os.remove(dst)
 
     logger.debug(f"Linking file from '{src}' to '{dst}'")
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     os.link(src, dst)
 
 


### PR DESCRIPTION
## Summary

Static assets stored in subdirectories would crash the linking process. A file like `images/logo.png` in your docs folder would fail when Luma tried to create a hard link to `.luma/public/images/logo.png`. The code assumed the destination directory already existed.

This adds a single line to create any missing parent directories before attempting the link. Without it, users couldn't organize their assets into folders.