### PR TITLE
Fix table of contents rendering for headings with inline code

### DIFF
--- a/src/luma/app/markdoc/nodes/heading.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/heading.markdoc.ts
@@ -1,6 +1,7 @@
 import { Tag, Node, Config, RenderableTreeNode } from "@markdoc/markdoc";
 
 import { Heading } from "../../components";
+import { extractTextFromChildren } from "../utils";
 
 function generateID(
   children: RenderableTreeNode[],
@@ -9,9 +10,8 @@ function generateID(
   if (attributes.id && typeof attributes.id === "string") {
     return attributes.id;
   }
-  return children
-    .filter((child) => typeof child === "string")
-    .join(" ")
+  const text = extractTextFromChildren(children);
+  return text
     .replace(/[?]/g, "")
     .replace(/\s+/g, "-")
     .toLowerCase();

--- a/src/luma/app/markdoc/utils.ts
+++ b/src/luma/app/markdoc/utils.ts
@@ -1,0 +1,28 @@
+import { RenderableTreeNodes, Tag } from "@markdoc/markdoc";
+
+/**
+ * Recursively extracts plain text from Markdoc RenderableTreeNodes,
+ * including text content from inline code elements.
+ *
+ * @param children - Array of Markdoc renderable tree nodes
+ * @returns The concatenated text content
+ */
+export function extractTextFromChildren(
+  children: RenderableTreeNodes[],
+): string {
+  let text = "";
+  for (const child of children) {
+    if (typeof child === "string") {
+      text += child;
+    } else if (Tag.isTag(child)) {
+      // Handle inline code and other inline elements
+      if (child.name === "code" && child.attributes.content) {
+        text += child.attributes.content;
+      } else if (child.children) {
+        // Recursively extract text from nested children
+        text += extractTextFromChildren(child.children);
+      }
+    }
+  }
+  return text;
+}

--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -32,6 +32,7 @@ const config = configData as Config;
 
 import { TableOfContentsItem } from "../components/TableOfContents";
 import { Page, Reference } from "../types/config";
+import { extractTextFromChildren } from "../markdoc/utils";
 
 function hasTabs(navigation: NavigationItem[]): boolean {
   return navigation.length > 0 && navigation[0].type === "tab";
@@ -97,12 +98,13 @@ function collectHeadings(
   // I think this function assumes the root node is an 'article' tag?
   if (Tag.isTag(node)) {
     if (node.name === "Heading") {
-      const title = node.children[0];
-
       const id = node.attributes.id || "ham"; // Assuming you have an ID generator
       const level = node.attributes.level || 1; // Default to level 1 if not provided
 
-      if (typeof title === "string") {
+      // Extract text from all children, including inline code
+      const title = extractTextFromChildren(node.children);
+
+      if (title) {
         sections.push({
           id,
           level,


### PR DESCRIPTION
The table of contents wasn't showing inline code in headings. If you wrote a heading like `## Use the \`foo\` method`, the TOC would display only "Use the method", dropping the code part entirely.

This happened because two separate functions were extracting text from heading nodes, and both ignored inline code elements. One function generated the heading ID, the other built the TOC. They grabbed only plain text strings and skipped over anything wrapped in backticks.

Now both functions use shared logic that handles all inline elements, including code. The TOC shows complete headings, and the IDs match what actually appears in the document.