### PR TITLE
Convert search bar to modal with blurred backdrop

### DIFF
--- a/src/luma/app/components/SearchBar.module.css
+++ b/src/luma/app/components/SearchBar.module.css
@@ -4,15 +4,95 @@
   margin-bottom: 1rem;
 }
 
+/* Trigger button */
+.triggerButton {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--color-text-tertiary);
+  background: white;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  text-align: left;
+}
+
+.triggerButton:hover {
+  border-color: #6366f1;
+}
+
+.triggerButton:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
+}
+
+.triggerText {
+  flex: 1;
+  color: var(--color-text-tertiary);
+}
+
+/* Modal overlay with blur */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  z-index: 99999;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Modal panel */
+.modalPanel {
+  width: 90%;
+  max-width: 600px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+  animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
 .inputWrapper {
   position: relative;
   display: flex;
   align-items: center;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .searchIcon {
   position: absolute;
-  left: 0.75rem;
+  left: 1rem;
   color: var(--color-text-tertiary);
   pointer-events: none;
 }
@@ -33,48 +113,33 @@
 
 .input {
   width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
-  font-size: 13px;
+  padding: 1rem 1rem 1rem 3rem;
+  font-size: 16px;
   font-family: inherit;
   color: var(--color-text-primary);
-  background: white;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  background: transparent;
+  border: none;
   outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .input::placeholder {
   color: var(--color-text-tertiary);
 }
 
-.input:focus {
-  border-color: #6366f1;
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
-}
-
-.dropdown {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  left: 0;
-  right: 0;
-  background: white;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+/* Results container */
+.results {
   max-height: 400px;
   overflow-y: auto;
-  z-index: 1000;
 }
 
 .result {
   width: 100%;
-  padding: 0.75rem;
+  padding: 0.875rem 1rem;
   text-align: left;
   background: none;
   border: none;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.15s;
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -88,7 +153,7 @@
 }
 
 .resultTitle {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
   margin-bottom: 0.25rem;
@@ -97,4 +162,12 @@
 .resultSection {
   font-size: 12px;
   color: var(--color-text-tertiary);
+}
+
+/* No results message */
+.noResults {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--color-text-tertiary);
+  font-size: 14px;
 }

--- a/src/luma/app/components/SearchBar.tsx
+++ b/src/luma/app/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "next/router";
 import MiniSearch from "minisearch";
 import styles from "./SearchBar.module.css";
@@ -25,7 +26,6 @@ export function SearchBar() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isOpen, setIsOpen] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -77,8 +77,7 @@ export function SearchBar() {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!isOpen || results.length === 0) {
       if (e.key === "Escape") {
-        setIsOpen(false);
-        inputRef.current?.blur();
+        closeModal();
       }
       return;
     }
@@ -102,8 +101,7 @@ export function SearchBar() {
         break;
       case "Escape":
         e.preventDefault();
-        setIsOpen(false);
-        inputRef.current?.blur();
+        closeModal();
         break;
     }
   };
@@ -111,9 +109,15 @@ export function SearchBar() {
   // Navigate to selected result
   const navigateToResult = (result: SearchResult) => {
     router.push(result.path);
+    closeModal();
+  };
+
+  // Close modal and reset state
+  const closeModal = () => {
     setIsOpen(false);
     setQuery("");
-    inputRef.current?.blur();
+    setResults([]);
+    setSelectedIndex(0);
   };
 
   // Handle "/" keyboard shortcut
@@ -151,61 +155,101 @@ export function SearchBar() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  return (
-    <div className={styles.container}>
-      <div className={styles.inputWrapper}>
-        <svg
-          className={styles.searchIcon}
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M7.333 12.667A5.333 5.333 0 1 0 7.333 2a5.333 5.333 0 0 0 0 10.667zM14 14l-2.9-2.9"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+  const modalContent = isOpen && (
+    <div className={styles.modalOverlay} onClick={closeModal}>
+      <div className={styles.modalPanel} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.inputWrapper}>
+          <svg
+            className={styles.searchIcon}
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.333 12.667A5.333 5.333 0 1 0 7.333 2a5.333 5.333 0 0 0 0 10.667zM14 14l-2.9-2.9"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            className={styles.input}
+            placeholder="Search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
-        </svg>
-        <input
-          ref={inputRef}
-          type="text"
-          className={styles.input}
-          placeholder="Search..."
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => {
+        </div>
+
+        {results.length > 0 && (
+          <div ref={dropdownRef} className={styles.results}>
+            {results.map((result, index) => (
+              <button
+                key={result.id}
+                className={`${styles.result} ${
+                  index === selectedIndex ? styles.resultSelected : ""
+                }`}
+                onClick={() => navigateToResult(result)}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                <div className={styles.resultTitle}>{result.title}</div>
+                {result.section && (
+                  <div className={styles.resultSection}>{result.section}</div>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {query.trim() && results.length === 0 && (
+          <div className={styles.noResults}>No results found</div>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Trigger button in sidenav */}
+      <div className={styles.container}>
+        <button
+          className={styles.triggerButton}
+          onClick={() => {
             setIsOpen(true);
-            setIsFocused(true);
+            // Focus input after modal opens
+            setTimeout(() => inputRef.current?.focus(), 10);
           }}
-          onBlur={() => setIsFocused(false)}
-          onKeyDown={handleKeyDown}
-        />
-        {!isFocused && <kbd className={styles.keyboardShortcut}>/</kbd>}
+        >
+          <svg
+            className={styles.searchIcon}
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7.333 12.667A5.333 5.333 0 1 0 7.333 2a5.333 5.333 0 0 0 0 10.667zM14 14l-2.9-2.9"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className={styles.triggerText}>Search...</span>
+          <kbd className={styles.keyboardShortcut}>/</kbd>
+        </button>
       </div>
 
-      {isOpen && results.length > 0 && (
-        <div ref={dropdownRef} className={styles.dropdown}>
-          {results.map((result, index) => (
-            <button
-              key={result.id}
-              className={`${styles.result} ${
-                index === selectedIndex ? styles.resultSelected : ""
-              }`}
-              onClick={() => navigateToResult(result)}
-              onMouseEnter={() => setSelectedIndex(index)}
-            >
-              <div className={styles.resultTitle}>{result.title}</div>
-              {result.section && (
-                <div className={styles.resultSection}>{result.section}</div>
-              )}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+      {/* Portal modal to document.body */}
+      {typeof document !== "undefined" &&
+        modalContent &&
+        createPortal(modalContent, document.body)}
+    </>
   );
 }

--- a/src/luma/app/components/SearchBar.tsx
+++ b/src/luma/app/components/SearchBar.tsx
@@ -130,13 +130,20 @@ export function SearchBar() {
         document.activeElement?.tagName !== "TEXTAREA"
       ) {
         event.preventDefault();
-        inputRef.current?.focus();
+        setIsOpen(true);
       }
     };
 
     document.addEventListener("keydown", handleKeyPress);
     return () => document.removeEventListener("keydown", handleKeyPress);
   }, []);
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 10);
+    }
+  }, [isOpen]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -219,11 +226,7 @@ export function SearchBar() {
       <div className={styles.container}>
         <button
           className={styles.triggerButton}
-          onClick={() => {
-            setIsOpen(true);
-            // Focus input after modal opens
-            setTimeout(() => inputRef.current?.focus(), 10);
-          }}
+          onClick={() => setIsOpen(true)}
         >
           <svg
             className={styles.searchIcon}


### PR DESCRIPTION
This PR updates the search bar so it renders as a modal rather than a dropdown in the sidenav. I think it looks better this way.

The modal renders via React portal to avoid stacking context issues. Without this, elements like the top nav and code blocks would render on top of the overlay despite z-index values.