### PR TITLE
Make individual headings searchable

### DIFF
--- a/src/luma/app/components/SearchBar.module.css
+++ b/src/luma/app/components/SearchBar.module.css
@@ -159,6 +159,19 @@
   margin-bottom: 0.25rem;
 }
 
+.resultPageTitle {
+  color: var(--color-text-secondary);
+}
+
+.resultHeadingSeparator {
+  color: var(--color-text-tertiary);
+  margin: 0 0.25rem;
+}
+
+.resultHeading {
+  color: var(--color-text-primary);
+}
+
 .resultSection {
   font-size: 12px;
   color: var(--color-text-tertiary);

--- a/src/luma/app/components/SearchBar.tsx
+++ b/src/luma/app/components/SearchBar.tsx
@@ -10,9 +10,10 @@ interface SearchDocument {
   id: string;
   title: string;
   path: string;
-  headings: string;
   content: string;
   section: string;
+  heading: string;
+  headingLevel: number;
 }
 
 interface SearchResult {
@@ -20,6 +21,8 @@ interface SearchResult {
   title: string;
   path: string;
   section: string;
+  heading: string;
+  headingLevel: number;
 }
 
 export function SearchBar() {
@@ -36,10 +39,10 @@ export function SearchBar() {
     const documents = searchIndexData as SearchDocument[];
 
     const miniSearch = new MiniSearch({
-      fields: ["title", "headings", "content"],
-      storeFields: ["title", "path", "section"],
+      fields: ["title", "heading", "content"],
+      storeFields: ["title", "path", "section", "heading", "headingLevel"],
       searchOptions: {
-        boost: { title: 3, headings: 2, content: 1 },
+        boost: { title: 3, heading: 2, content: 1 },
         fuzzy: 0.2,
         prefix: true,
       },
@@ -64,6 +67,8 @@ export function SearchBar() {
         title: result.title,
         path: result.path,
         section: result.section,
+        heading: result.heading,
+        headingLevel: result.headingLevel,
       }));
       setResults(limitedResults);
       setSelectedIndex(0);
@@ -204,7 +209,21 @@ export function SearchBar() {
                 onClick={() => navigateToResult(result)}
                 onMouseEnter={() => setSelectedIndex(index)}
               >
-                <div className={styles.resultTitle}>{result.title}</div>
+                <div className={styles.resultTitle}>
+                  {result.heading ? (
+                    <>
+                      <span className={styles.resultPageTitle}>
+                        {result.title}
+                      </span>
+                      <span className={styles.resultHeadingSeparator}> › </span>
+                      <span className={styles.resultHeading}>
+                        {result.heading}
+                      </span>
+                    </>
+                  ) : (
+                    result.title
+                  )}
+                </div>
                 {result.section && (
                   <div className={styles.resultSection}>{result.section}</div>
                 )}


### PR DESCRIPTION
The search bar now treats each heading as its own result. Before, headings were mashed together into one blob per page. If you searched for a specific section, you got the page but had to hunt for the section yourself.

Now each h1, h2, and h3 gets its own entry in the search index. Results show both the page title and the heading, separated by a chevron. Click a heading result and you jump straight there via anchor link.

This helps when documentation grows. You want the thing, not the haystack.

## What changed

**Python backend (`search.py`):**
- Added `_slugify()` to convert headings into URL fragments while preserving dots for API references
- Changed `_extract_page_content()` to return a list of search documents instead of one
- Each page now produces multiple index entries: one for the page itself, plus one per heading

**TypeScript frontend (`SearchBar.tsx`):**
- Updated data types to include `heading` and `headingLevel` fields
- Changed search configuration to index individual headings instead of a concatenated string
- Updated results display to show "Page Title › Heading" for heading matches

**CSS (`SearchBar.module.css`):**
- Added styles to visually distinguish page titles from headings in results