### PR TITLE
Fix images

### DIFF
--- a/docs/syntax/images.md
+++ b/docs/syntax/images.md
@@ -3,7 +3,7 @@
 ---
 
 ```markdown
-![Alt text](/cat.png)
+![Alt text](cat.png)
 ```
 
-![Alt text](/cat.png)
+![Alt text](cat.png)

--- a/docs/syntax/images.md
+++ b/docs/syntax/images.md
@@ -3,7 +3,7 @@
 ---
 
 ```markdown
-![Alt text](cat.png)
+![Alt text](/cat.png)
 ```
 
-![Alt text](cat.png)
+![Alt text](/cat.png)

--- a/src/luma/app/markdoc/nodes/image.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/image.markdoc.ts
@@ -1,7 +1,7 @@
-import { Config, Node, Tag } from '@markdoc/markdoc';
+import { Config, Node, Tag } from "@markdoc/markdoc";
 
 export const image = {
-  render: 'img',
+  render: "img",
   attributes: {
     src: { type: String, required: true },
     alt: { type: String },
@@ -14,7 +14,7 @@ export const image = {
     const version = process.env.NEXT_PUBLIC_RELEASE_VERSION || null;
     const basePath = version ? `/${version}` : "";
 
-    const modifiedSrc = attributes.src.startsWith('http') || attributes.src.startsWith('/')
+    const modifiedSrc = attributes.src.startsWith("http")
       ? attributes.src 
       : `${basePath}/${attributes.src}`;
     

--- a/src/luma/app/markdoc/nodes/image.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/image.markdoc.ts
@@ -13,15 +13,11 @@ export const image = {
 
     const version = process.env.NEXT_PUBLIC_RELEASE_VERSION || null;
     const basePath = version ? `/${version}` : "";
-
-    console.log(attributes.src)
     var imagePath = attributes.src
 
     if (imagePath.startsWith("/")) {
         imagePath = imagePath.slice(1)
     }
-
-    console.log(imagePath)
 
     const modifiedSrc = imagePath.startsWith("http")
       ? imagePath 

--- a/src/luma/app/markdoc/nodes/image.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/image.markdoc.ts
@@ -14,9 +14,18 @@ export const image = {
     const version = process.env.NEXT_PUBLIC_RELEASE_VERSION || null;
     const basePath = version ? `/${version}` : "";
 
-    const modifiedSrc = attributes.src.startsWith("http")
-      ? attributes.src 
-      : `${basePath}/${attributes.src}`;
+    console.log(attributes.src)
+    var imagePath = attributes.src
+
+    if (imagePath.startsWith("/")) {
+        imagePath = imagePath.slice(1)
+    }
+
+    console.log(imagePath)
+
+    const modifiedSrc = imagePath.startsWith("http")
+      ? imagePath 
+      : `${basePath}/${imagePath}`;
     
     return new Tag(
       this.render,

--- a/src/luma/app/markdoc/nodes/image.markdoc.ts
+++ b/src/luma/app/markdoc/nodes/image.markdoc.ts
@@ -1,0 +1,27 @@
+import { Config, Node, Tag } from '@markdoc/markdoc';
+
+export const image = {
+  render: 'img',
+  attributes: {
+    src: { type: String, required: true },
+    alt: { type: String },
+    title: { type: String }
+  },
+  transform(node: Node, config: Config) {
+    const attributes = node.transformAttributes(config);
+    const children = node.transformChildren(config);
+
+    const version = process.env.NEXT_PUBLIC_RELEASE_VERSION || null;
+    const basePath = version ? `/${version}` : "";
+
+    const modifiedSrc = attributes.src.startsWith('http') || attributes.src.startsWith('/')
+      ? attributes.src 
+      : `${basePath}/${attributes.src}`;
+    
+    return new Tag(
+      this.render,
+      { ...attributes, src: modifiedSrc },
+      children
+    );
+  }
+};

--- a/src/luma/app/markdoc/nodes/index.ts
+++ b/src/luma/app/markdoc/nodes/index.ts
@@ -2,5 +2,6 @@
 /* Use this file to export your markdoc nodes */
 export * from "./fence.markdoc";
 export * from "./heading.markdoc";
+export * from "./image.markdoc"
 export * from "./link.markdoc";
 export * from "./text.markdoc";


### PR DESCRIPTION
Add markdoc node to prefix image paths with the `version` if set. Images can be specified in markdown with `path.png` or `/path.png`

https://fix-cat.luma-docs.org/latest/syntax/images