### PR TITLE
Check package name env var to display version selector

### DIFF
--- a/src/luma/app/pages/_app.tsx
+++ b/src/luma/app/pages/_app.tsx
@@ -213,7 +213,7 @@ export default function MyApp({ Component, pageProps }: AppProps<MyAppProps>) {
                 <div className="toc-placeholder" />
               )}
             </div>
-            {process.env.NEXT_PUBLIC_RELEASE_VERSION != null && (
+            {process.env.NEXT_PUBLIC_PACKAGE_NAME != null && (
               <VersionSelector />
             )}
           </main>


### PR DESCRIPTION
Check `NEXT_PUBLIC_PACKAGE_NAME` to determine if version selector should be displayed. `NEXT_PUBLIC_RELEASE_VERSION` will no longer be set on `latest` deployments to support removing `/latest` from subpaths, so all routes on the latest deployment will be from `/` (ex. `/overview` instead of `/latest/overview`).

I'll have to manually update the rewrites for `luma` and `requests` once this is merged

https://latest-routing.luma-docs.org/