### PR TITLE
No copy REPL

### DIFF
--- a/src/luma/app/components/CodeBlock.module.css
+++ b/src/luma/app/components/CodeBlock.module.css
@@ -42,3 +42,10 @@
   border-bottom: 1px solid #505864;
   border-radius: 4px 4px 0 0;
 }
+
+.code :global(.prompt-symbol) {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/src/luma/app/components/CodeBlock.tsx
+++ b/src/luma/app/components/CodeBlock.tsx
@@ -25,7 +25,7 @@ export function CodeBlock({
         .replace(
           /(<span class="token operator">&gt;&gt;<\/span><span class="token operator">&gt;<\/span>)/g,
           '<span class="prompt-symbol">$1</span>',
-        )
+        );
       ref.current.innerHTML = processedHtml;
     }
   }, [children, isOutput]);

--- a/src/luma/app/components/CodeBlock.tsx
+++ b/src/luma/app/components/CodeBlock.tsx
@@ -12,11 +12,22 @@ export function CodeBlock({
   children,
   "data-language": language,
 }: CodeBlockProps) {
-  const ref = React.useRef(null);
+  const ref = React.useRef<HTMLPreElement>(null);
   const isOutput = language === "output";
 
   React.useEffect(() => {
-    if (ref.current && !isOutput) Prism.highlightElement(ref.current, false);
+    if (ref.current && !isOutput) {
+      Prism.highlightElement(ref.current, false);
+      const html = ref.current.innerHTML;
+
+      const processedHtml = html
+        // Match >>> (three consecutive operator spans with &gt;)
+        .replace(
+          /(<span class="token operator">&gt;&gt;<\/span><span class="token operator">&gt;<\/span>)/g,
+          '<span class="prompt-symbol">$1</span>',
+        )
+      ref.current.innerHTML = processedHtml;
+    }
   }, [children, isOutput]);
 
   return (


### PR DESCRIPTION
Add post-processing to `CodeBlock` component to apply `prompt-symbol` class to `>>>`. Prism applies `token-operator` by default, but this is also applied to `=` which we don't want to affect.

https://no-copy-repl.luma-docs.org/syntax/code-snippets